### PR TITLE
feat: 制品签名信任锚与国内镜像下载通道(ADR 0036)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,37 @@ jobs:
       - name: Verify tarballs against SHA256SUMS
         run: bash scripts/release/verify.sh dist/release
 
+      - name: Install minisign
+        run: sudo apt-get update && sudo apt-get install -y minisign
+
+      - name: Sign SHA256SUMS with minisign
+        env:
+          MINISIGN_PRIVATE_KEY: ${{ secrets.MINISIGN_PRIVATE_KEY }}
+        run: |
+          set -Eeuo pipefail
+          # An unsigned release must never ship: an absent secret is a hard
+          # configuration error, distinct from a signing failure below.
+          if [[ -z "${MINISIGN_PRIVATE_KEY:-}" ]]; then
+            echo "MINISIGN_PRIVATE_KEY secret is not configured; refusing to publish an unsigned release" >&2
+            exit 1
+          fi
+          # The secret lands on disk only inside this throwaway key file and
+          # is never echoed (GitHub additionally masks secret values in logs).
+          keyfile="$(mktemp)"
+          trap 'rm -f "$keyfile"' EXIT
+          printf '%s\n' "$MINISIGN_PRIVATE_KEY" >"$keyfile"
+          cd dist/release
+          # Legacy (non-prehashed) format is mandatory: minisign >= 0.11
+          # prehashes by default, and the openssl verifier in
+          # scripts/install/lib.sh only accepts "Ed" signatures.
+          minisign -S -l -s "$keyfile" -x SHA256SUMS.minisig -m SHA256SUMS
+          [[ -f SHA256SUMS.minisig ]] || { echo "minisign produced no SHA256SUMS.minisig" >&2; exit 1; }
+
+      # Round-trip through the same verifier installers use: catches a
+      # mismatched embedded public key / secret pair before anything uploads.
+      - name: Verify signature with the embedded public key
+        run: bash scripts/release/verify.sh dist/release
+
       - name: Attest build provenance of tarballs
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
@@ -137,7 +168,8 @@ jobs:
           bash scripts/release/notes.sh "$RELEASE_TAG" > dist/release-notes.md
           gh release create "$RELEASE_TAG" "${args[@]}" \
             dist/release/proxyhub_*.tar.gz \
-            dist/release/SHA256SUMS
+            dist/release/SHA256SUMS \
+            dist/release/SHA256SUMS.minisig
 
   docker:
     name: Publish GHCR multi-arch image

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -188,6 +188,14 @@ _区别_: 关键词/地区白名单过滤的是下发哪些节点;地域白名�
 统一规则表 `ip_access_rules` 中 scope=global 的规则,由挂在 Site Path 中间件之后、路由分发之前的拒止中间件执行,命中即统一 404(与 Site Path 未命中逐字节一致,不暴露任何存在性);store 查询失败 fail-open;loopback 永远豁免(SSH 隧道是逃生门)。拉取防护的自动黑名单条目为 scope=sub(只拒 /sub),超管可在审计页"IP 规则"区块一键升级为 global;手动条目建时选定 scope。纯黑名单模型——管理面白名单已否决(自锁风险大于收益,Site Path + loopback 监听 + Caddy 层白名单三道既有防线充分,否决记录见 ADR 0033)。
 _区别_: 登录 IP2Ban 是带失败计数的自动处置(handleLogin 内,独立表);整站黑名单是显式规则 + 全路由中间件。
 
+**下载基 (Download Base)**:
+安装器与 `proxyhubctl update` 拉取制品(release tarball、SHA256SUMS、SHA256SUMS.minisig、伴侣库)的 URL 基址。默认 GitHub 官方 releases,可经 `--download-base` / `PROXYHUB_DOWNLOAD_BASE` 显式覆盖为镜像地址(国内场景);不内置任何第三方镜像为默认,无静默回退。镜像模式下 latest 自动解析不可用,必须显式 `--version`。下载基写入安装档案 `DOWNLOAD_BASE=` 字段,update 自动沿用(显式参数优先)。制品真实性不依赖下载基的可信度——由签名信任锚保证(见 ADR 0036)。
+_Avoid_: 镜像站(镜像只是下载基的一种取值)
+
+**签名信任锚 (Signature Trust Anchor)**:
+制品真实性验证的根:内嵌在 install.sh/proxyhubctl 里的 minisign 公钥。release.yml 用私钥(GitHub Secrets)给 SHA256SUMS 签名,安装/更新时以 openssl 验签(Ed25519,不引入 minisign 依赖),再按验过的 SHA256SUMS 核校 tarball。链条:内嵌公钥 → SHA256SUMS.minisig → SHA256SUMS → tarball。有了它,制品从任何传输通道(GitHub/镜像/CDN/离线拷贝)下载都不影响真实性;缺签名或验签失败 fail closed(见 ADR 0036)。
+_区别_: 校验和(SHA256SUMS)只防传输损坏,同源下发时防不了源被替换;签名信任锚防替换。
+
 **Caddy 模式 (Caddy Mode)**:
 一键安装器对目标机 Caddy 拓扑的识别结果,三态:`native`(宿主机原生 systemd Caddy,`command -v caddy` 探测)/ `docker`(容器化 Caddy,见"Docker Caddy 模式")/ `none`(`--no-caddy`,运维自带反代,安装器只写示例文件)。记录在安装档案的 `CADDY_MODE` 字段,proxyhubctl 的 update/repair/rotate-path/uninstall 读档案后走对应通道;旧档案缺省按 `native` 兼容。模式优先级:`--caddy-docker` 强制 docker > 有 caddy 二进制走 native > 自动探测单个 docker caddy 容器 > fail closed(见 ADR 0035)。
 _Avoid_: 反代模式、部署模式

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -148,7 +148,7 @@ GitHub（raw.githubusercontent.com、github.com/releases）在国内大面积不
 curl -fsSL https://cdn.jsdelivr.net/gh/taliove/proxyhub@main/install.sh | bash
 ```
 
-安装器运行期拉取伴侣库（lib.sh、proxyhubctl）同样 jsDelivr 优先、raw.githubusercontent 后备，两者都失败才报错退出。注意：jsDelivr 只解决「脚本入口」，制品（tarball）默认仍从 GitHub releases 下载——GitHub 整体不可达的机器还必须配合下面的镜像下载基。
+安装器运行期拉取伴侣库（lib.sh、proxyhubctl）同样 jsDelivr 优先、raw.githubusercontent 后备，两者都失败才报错退出。注意：jsDelivr 只解决「脚本入口」，制品（tarball）默认仍从 GitHub releases 下载——GitHub 整体不可达的机器还必须配合下面的镜像下载基。另请注意 jsDelivr 的 `@main` 缓存最长约 12 小时：刚发布的版本（尤其公钥轮换后的首个版本）经 jsDelivr 入口可能拿到旧脚本，此时改用 raw.githubusercontent 入口或等缓存过期。
 
 ### 制品走镜像：--download-base
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -138,6 +138,74 @@ bash <(curl -fsSL https://raw.githubusercontent.com/taliove/proxyhub/main/instal
 
 注意：`--no-caddy` 安装的实例，`proxyhubctl rotate-path` 不可用（它无法改写你自己的反代配置）；换 Site Path 需手工同步你的反代配置与样例文件。
 
+## 国内部署（网络受限环境）
+
+GitHub（raw.githubusercontent.com、github.com/releases）在国内大面积不可达，默认安装入口与制品下载都会卡住。本节给出完整替代路径：入口脚本走 jsDelivr CDN，制品下载走 `--download-base` 指向的镜像。安全性不依赖镜像可信，见下文「签名信任锚」。
+
+### 入口：jsDelivr
+
+```bash
+curl -fsSL https://cdn.jsdelivr.net/gh/taliove/proxyhub@main/install.sh | bash
+```
+
+安装器运行期拉取伴侣库（lib.sh、proxyhubctl）同样 jsDelivr 优先、raw.githubusercontent 后备，两者都失败才报错退出。注意：jsDelivr 只解决「脚本入口」，制品（tarball）默认仍从 GitHub releases 下载——GitHub 整体不可达的机器还必须配合下面的镜像下载基。
+
+### 制品走镜像：--download-base
+
+`--download-base URL`（或环境变量 `PROXYHUB_DOWNLOAD_BASE`，旗标优先）覆盖制品下载基，制品 URL 按 `<base>/<version>/<asset>` 解析，URL 必须是 https://。默认值永远是 GitHub 官方 releases，不内置任何第三方镜像。镜像模式下 latest 自动解析不可用（它依赖 GitHub 重定向），**必须显式 `--version`**，否则安装器直接拒绝并提示；下载基不可达时报错并给出指引，无静默回退。
+
+配方（镜像 + 显式版本）：
+
+```bash
+curl -fsSL https://cdn.jsdelivr.net/gh/taliove/proxyhub@main/install.sh -o install.sh
+bash install.sh --non-interactive \
+  --domain proxy.example.com \
+  --version 0.3.0 \
+  --download-base https://<镜像>/taliove/proxyhub/releases/download
+```
+
+`--version` 取一个已发布的版本号（去 releases 页或 CHANGELOG 挑；镜像转发的是同一批 release 资产）。
+
+**镜像从哪来**：前缀转发型 ghproxy 类公共服务是当前常见形态——下载基写成「镜像域名前缀 + 原始 GitHub 路径」的拼接，形如 `https://ghproxy.example.com/https://github.com/taliove/proxyhub/releases/download`；自建 nginx 反代 `https://github.com/taliove/proxyhub/releases/download/` 是更稳定的选项。**任何第三方镜像都会过期，本仓库不担保任何具体镜像的可用性，以你实际可达为准**。自查方法：直接探测该镜像能否取到完整制品——
+
+```bash
+curl -fsSI https://<镜像>/<version>/SHA256SUMS.minisig
+```
+
+签名文件（.minisig）与 tarball 都能拿到才算完整转发；只转发热门大文件、丢掉小签名文件的镜像，安装器会 fail closed（见下节）。
+
+### 为什么镜像下载也安全（签名信任锚）
+
+release 资产除 tarball 与 SHA256SUMS 外还包含 `SHA256SUMS.minisig`——发布方用私钥对 SHA256SUMS 的数字签名。安装器与 `proxyhubctl update` 内嵌对应公钥，下载后先用 openssl 验签，再按验过的 SHA256SUMS 核校 tarball；签名缺失、格式非法或验签失败一律 fail closed，拒绝安装。信任链是「内嵌公钥 → 签名 → 校验和 → 制品」，与下载通道无关：恶意镜像可以同时替换 tarball 和 SHA256SUMS，但伪造不出能通过内嵌公钥验签的签名。验签只需要 openssl（≥ 1.1.1，Ubuntu 22.04+/Debian 12+ 自带），不引入新依赖。决策细节见 [ADR 0036](adr/0036-artifact-signing-and-mirror-channel.md)。
+
+### 更新沿用下载基
+
+安装时生效的下载基写入安装档案（`/root/.proxyhub-install-info` 的 `DOWNLOAD_BASE=` 字段），`proxyhubctl update` 自动沿用，升级不必重记镜像参数；显式 `--download-base` 优先于档案值，是换镜像时的确定性覆盖手段。镜像模式下 update 同样需要显式 `--version`。
+
+> **注意**：镜像模式的安装不宜启用自动更新（`proxyhubctl auto-update enable`）——自动更新不带显式版本，按镜像版本纪律会被拒绝；请定期手动 `proxyhubctl update --version <版本>`。
+
+### Caddy 镜像：Docker 加速器
+
+caddy 容器镜像拉自 Docker Hub，国内同样受限。给 Docker 配 registry mirror 后重拉：
+
+```json
+// /etc/docker/daemon.json
+{
+  "registry-mirrors": ["https://<你的加速器地址>"]
+}
+```
+
+```bash
+systemctl restart docker
+docker pull caddy:2
+```
+
+加速器地址由你的云厂商控制台或所用镜像服务提供（阿里云、腾讯云等为每个账号分配专属地址），同样以实际可达为准。宿主原生 Caddy（Cloudsmith 仓库）国内一般可达；不可达时改用 Docker Caddy 模式（见「Docker 容器中的 Caddy」）。
+
+### GeoIP 库
+
+订阅拉取地域白名单依赖的 GeoIP 库，更新源 `download.db-ip.com` 国内基本可达，通常无需处理；确有障碍时 `scripts/geoip/update.sh` 支持 `GEOIP_BASE_URL` 覆盖下载基。
+
 ## 一键安装
 
 ### 交互式安装（推荐）

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -179,6 +179,35 @@ A: 在——只要重建后的容器仍然挂载同一个 `/etc/caddy` 持久目
 1. **容器名变了**：安装档案（`/root/.proxyhub-install-info`）里的 `CADDY_CONTAINER` 记的是安装时的容器名，改名后 `proxyhubctl` 会因找不到容器而 fail closed。编辑档案把 `CADDY_CONTAINER` 改成新容器名即可，不必重装；
 2. **桥接拓扑参数丢了**：重建时丢了 `--add-host host.docker.internal:host-gateway`、80/443 端口发布或换了网桥，`proxyhubctl rotate-path` 等操作会在校验阶段 fail closed，按报错指引补齐参数即可。
 
+## 国内网络环境
+
+### Q: 国内服务器（GitHub 不可达）怎么装 ProxyHub？
+
+A: 三步：入口脚本走 jsDelivr CDN，制品下载用 `--download-base` 指向一个你可达的镜像，并且**必须显式 `--version`**（镜像模式下 latest 自动解析不可用，安装器会直接拒绝）：
+
+```bash
+curl -fsSL https://cdn.jsdelivr.net/gh/taliove/proxyhub@main/install.sh -o install.sh
+bash install.sh --non-interactive --domain proxy.example.com \
+  --version <已发布版本号> \
+  --download-base https://<镜像>/taliove/proxyhub/releases/download
+```
+
+镜像怎么选、可达性怎么自查、caddy 容器镜像与 GeoIP 的配套说明，见 [DEPLOY.md](DEPLOY.md)「国内部署」一节。
+
+### Q: 从第三方镜像下载的制品安全吗？
+
+A: 安全性不靠镜像自觉，靠密码学验签。发布方用私钥给校验和文件（SHA256SUMS）签了名，release 资产里多一个 `SHA256SUMS.minisig`；安装器与更新器内嵌对应公钥，下载后先验签、再按验过的校验和核校 tarball，任何一步不过都拒绝安装。恶意镜像可以同时替换 tarball 和校验和，但伪造不出能通过内嵌公钥的签名——缺签名文件、签名对不上，安装直接中止（fail closed）。验签只用系统自带的 openssl，不装新工具。原理与决策见 [ADR 0036](adr/0036-artifact-signing-and-mirror-channel.md)。
+
+### Q: 国内装的实例，`proxyhubctl update` 怎么用？
+
+A: 安装时的下载基记在 `/root/.proxyhub-install-info` 的 `DOWNLOAD_BASE` 字段，update 自动沿用——当初走镜像装的，升级时不必再传 `--download-base`：
+
+```bash
+proxyhubctl update --version <目标版本号>
+```
+
+镜像模式必须显式 `--version`（latest 解析依赖 GitHub）。要换镜像时显式给 `--download-base`，显式参数优先于档案里的值。
+
 ## 订阅与节点
 
 ### Q: 订阅突然拉不到了(403/404/429)，怎么排查？

--- a/docs/adr/0036-artifact-signing-and-mirror-channel.md
+++ b/docs/adr/0036-artifact-signing-and-mirror-channel.md
@@ -1,0 +1,41 @@
+# ADR 0036: 制品签名信任锚与国内镜像下载通道
+
+## 状态
+
+accepted
+
+## 上下文
+
+一键安装器的下载链全部锚在 GitHub:入口脚本与伴侣库(raw.githubusercontent.com)、连通性自检(github.com,硬编码)、latest 解析与制品下载(github.com/releases)、`proxyhubctl update`(api.github.com)。国内用户在这些点上大面积不可达,功能等同不可用。
+
+简单答案是"加个镜像参数",但它动摇安全模型的根基:现有模型的信任锚是 **GitHub HTTPS 本身**——SHA256SUMS 与 tarball 同源,校验和只防传输损坏,防不了源被替换。第三方镜像(ghproxy 类)可同时替换 tarball 与校验和,且这类公益镜像生命周期短、有劫持前科。支持镜像的前提是把信任锚从传输通道挪到密码学签名上。
+
+关键权衡:
+
+1. **签名方案**:minisign(单私钥,签名格式简单)vs cosign keyless(验证依赖 rekor 等在线服务,国内同样不可达)vs GPG(密钥分发与验证都重)。minisign 胜出:私钥一把存 GitHub Secrets,签名在 release.yml 内一步完成。
+2. **验签依赖**:目标机是全新 Ubuntu/Debian,minisign 二进制不在默认源,让安装器先装验签工具等于再造一条供应链。minisign 签名本质是 Ed25519——openssl(既有基础依赖)可从 `.minisig` 拆出 64 字节签名、用内嵌公钥拼 PEM 完成验签,零新增依赖。
+3. **镜像默认值的信任**:任何具体第三方镜像都不该成为默认值(churn、劫持前科),默认值永远 GitHub 官方;镜像只做显式参数,信任决策留给运维——与安装器 fail-closed 性格一致。有了签名,镜像选择不再影响制品真实性。
+4. **latest 解析的通道依赖**:latest tag 解析走 GitHub 重定向/api,镜像无法可靠代理;镜像模式要求显式 `--version`,fail-closed 胜过发明不可靠的解析链。
+5. **静默回退**:GitHub 不通自动回退镜像列表,违背 fail-closed 性格且回退顺序可被攻击者诱导,否决。
+
+## 决策
+
+1. **签名信任锚**:release.yml 用 minisign 私钥(GitHub Secrets)给 `SHA256SUMS` 签名,产物新增 `SHA256SUMS.minisig` 资产。install.sh 与 proxyhubctl 内嵌 minisign 公钥,下载后用 openssl 验签(从 `.minisig` 拆签名、公钥拼 PEM,不引入 minisign 依赖);缺签名文件或验签失败 fail closed。信任链:内嵌公钥 → `SHA256SUMS.minisig` → `SHA256SUMS` → tarball;传输通道不再承担信任。
+2. **下载基参数**:`--download-base URL`(及 `PROXYHUB_DOWNLOAD_BASE` 环境变量)覆盖连通性自检、制品与校验和/签名下载、伴侣库拉取;默认值永远 GitHub 官方,不内置任何第三方镜像为默认。镜像模式必须显式 `--version`,缺省 fail closed 并指引。无静默回退:GitHub 不通时报错并给出 `--download-base` 指引。
+3. **update 同源**:`proxyhubctl update` 走同一下载基与验签;下载基写入安装档案 `DOWNLOAD_BASE=` 字段,更新自动沿用(显式参数优先于档案值)。
+4. **国内入口**:jsDelivr 文档化入口(`cdn.jsdelivr.net/gh/<owner>/<repo>@main/install.sh`);脚本拉取伴侣库(install.sh 的 lib.sh 与 proxyhubctl)优先同 ref jsDelivr、GitHub 后备——这两个文件不携带信任,真正的信任锚是验签。
+5. **文档**:DEPLOY.md 增「国内部署」节(jsDelivr 入口、`--download-base` 用法与镜像配方、caddy 镜像的 Docker 加速器、GeoIP 无碍说明),FAQ 增问答。
+
+## 理由
+
+- 签名把"敢不敢用镜像"从信任判断变成密码学验证,这是镜像通道唯一负责任的开法;minisign 是该约束下最轻的签名体系(单 key、无在线验证依赖)。
+- openssl 验签免去目标机装验签工具的供应链套娃;openssl 是 TLS 栈既有依赖,全新 Ubuntu/Debian 必有。
+- 参数覆盖而非内置镜像,把 churn 与信任决策移出代码;安装器的默认值永远指向它能担保的官方源。
+- 显式 `--version` 要求与无静默回退,延续安装器"永不猜测"的既定性格(域名、凭证、容器选择的同款处理)。
+
+## 后果
+
+- 发布流程新增一次性运维:生成 minisign 密钥对,私钥入 GitHub Secrets,公钥嵌进 install.sh/proxyhubctl(公钥轮换即发新版,旧公钥验不了新制品属预期)。
+- release 资产新增 `SHA256SUMS.minisig`;verify.sh 与打包演练同步覆盖签名产出与验签(本地临时密钥)。
+- 镜像模式下 latest 自动解析不可用,`--version` 成为必选项;`proxyhubctl update`(无显式版本时)在镜像模式下同样要求显式版本或回退 GitHub。
+- 术语见 CONTEXT.md「下载基」「签名信任锚」。

--- a/install.sh
+++ b/install.sh
@@ -28,19 +28,37 @@ fi
 _PH_LIB_TMP=""
 if [[ -z $_ph_lib ]]; then
     # Only HTTPS is acceptable for root-executed code; file:// stays available
-    # to the test suite via PROXYHUB_ROOT.
-    _ph_lib_url="${PROXYHUB_LIB_URL:-https://raw.githubusercontent.com/taliove/proxyhub/main/scripts/install/lib.sh}"
-    if [[ $_ph_lib_url != https://* && -z ${PROXYHUB_ROOT:-} ]]; then
-        printf '[proxyhub] ERROR: PROXYHUB_LIB_URL must use https:// (got %s)\n' "$_ph_lib_url" >&2
+    # to the test suite via PROXYHUB_ROOT. Source candidates (ADR 0036): an
+    # explicit PROXYHUB_LIB_URL wins over everything (no fallback when it
+    # fails); otherwise jsDelivr (same @main ref as the documented CN entry)
+    # first, raw.githubusercontent as fallback. The companion lib carries no
+    # trust - the release signature verified below is the trust anchor.
+    if [[ -n ${PROXYHUB_LIB_URL:-} && ${PROXYHUB_LIB_URL} != https://* && -z ${PROXYHUB_ROOT:-} ]]; then
+        printf '[proxyhub] ERROR: PROXYHUB_LIB_URL must use https:// (got %s)\n' "${PROXYHUB_LIB_URL}" >&2
         exit 1
+    fi
+    _ph_lib_urls=()
+    if [[ -n ${PROXYHUB_LIB_URL:-} ]]; then
+        _ph_lib_urls=("${PROXYHUB_LIB_URL}")
+    else
+        _ph_lib_urls=(
+            "https://cdn.jsdelivr.net/gh/taliove/proxyhub@main/scripts/install/lib.sh"
+            "https://raw.githubusercontent.com/taliove/proxyhub/main/scripts/install/lib.sh"
+        )
     fi
     _PH_LIB_TMP=$(mktemp -d)
     chmod 700 "$_PH_LIB_TMP"
-    if ! curl -fsSL "$_ph_lib_url" -o "$_PH_LIB_TMP/lib.sh"; then
-        printf '[proxyhub] ERROR: cannot locate scripts/install/lib.sh locally, and download from %s failed\n' "$_ph_lib_url" >&2
+    for _ph_lib_url in "${_ph_lib_urls[@]}"; do
+        if curl -fsSL "$_ph_lib_url" -o "$_PH_LIB_TMP/lib.sh" 2>/dev/null; then
+            _ph_lib="$_PH_LIB_TMP/lib.sh"
+            break
+        fi
+        printf '[proxyhub] WARNING: companion lib download failed, trying next source: %s\n' "$_ph_lib_url" >&2
+    done
+    if [[ -z $_ph_lib ]]; then
+        printf '[proxyhub] ERROR: cannot locate scripts/install/lib.sh locally, and every download source failed\n' >&2
         exit 1
     fi
-    _ph_lib="$_PH_LIB_TMP/lib.sh"
 fi
 # Resolved companion-lib path, kept for the proxyhubctl install step
 # (_ph_lib itself is unset below with the other search temporaries).
@@ -49,7 +67,7 @@ _PH_LIB_PATH="$_ph_lib"
 # shellcheck source=scripts/install/lib.sh
 # shellcheck disable=SC1090,SC1091
 source "$_ph_lib"
-unset _ph_lib _ph_lib_candidate
+unset _ph_lib _ph_lib_url _ph_lib_urls
 
 # Constants and mutable globals (initialized for `set -u` sourcing)
 readonly PROXYHUB_DEFAULT_REPO="taliove/proxyhub"
@@ -62,13 +80,10 @@ NON_INTERACTIVE=0 DOMAIN="" EMAIL="" VERSION="latest" VERSION_TAG=""
 REPO="$PROXYHUB_DEFAULT_REPO" ARG_SITE_PATH="" SITE_PATH="" SKIP_DNS_CHECK=0
 DETECTED_OS="" DETECTED_ARCH="" ADMIN_USER="" ADMIN_PASSWORD="" ARG_LISTEN_ADDR=""
 TIMESTAMP="" WORKDIR="" CADDY_BACKUP="" NO_CADDY=0 ARG_CADDY_DOCKER=""
+# Download base (ADR 0036): --download-base wins over PROXYHUB_DOWNLOAD_BASE;
+# empty means the official GitHub releases base (resolved in parse_args).
+ARG_DOWNLOAD_BASE="" DOWNLOAD_BASE=""
 
-# _ph_fail MSG... - print each MSG as an error line and return 1 (guard helper).
-_ph_fail() {
-    local _m
-    for _m in "$@"; do _ph_err "$_m"; done
-    return 1
-}
 # _ph_die2 MSG... - print an error line and exit 2 (usage-error helper).
 _ph_die2() { _ph_err "$@"; exit 2; }
 
@@ -90,6 +105,12 @@ OPTIONS
   --version VERSION      "latest" (default) or explicit semver (1.2.3 / v1.2.3).
                          Pre-releases require an explicit value.
   --repo OWNER/REPO      GitHub releases source (default: taliove/proxyhub).
+  --download-base URL    Mirror download base for release artifacts (ADR 0036;
+                         default: GitHub official releases). https:// only;
+                         artifact URLs resolve as URL/<version>/<name>. A
+                         custom base requires an explicit --version and is
+                         probed for connectivity instead of github.com.
+                         Env: PROXYHUB_DOWNLOAD_BASE (the flag wins).
   --site-path PATH       Custom Site Path: 20-64 chars of [A-Za-z0-9_-], >=3
                          character classes, no reserved words.
   --listen-addr ADDR     Loopback listen address as 127.0.0.1:PORT
@@ -118,7 +139,9 @@ BEHAVIOR
   READ-ONLY host validation (OS: Ubuntu 22.04/24.04/26.04, Debian 12/13; amd64/arm64;
   systemd; root; outbound HTTPS; DNS; TCP 80/443 free or Caddy-owned) - never
   touches DNS, firewalls, or security groups. Downloads the release tarball +
-  SHA256SUMS over verified HTTPS; checksum verified BEFORE unpacking. Installs
+  SHA256SUMS + SHA256SUMS.minisig over verified HTTPS; the minisign signature
+  over SHA256SUMS is verified against the embedded release public key BEFORE
+  the tarball checksum, which is verified BEFORE unpacking (ADR 0036). Installs
   the binary, proxyhub user, directories, config.yaml, systemd unit; generates
   admin credentials passed to `proxyhub init` via stdin (never argv); writes,
   validates and reloads the Caddy fragment; verifies BOTH the loopback and the
@@ -153,6 +176,7 @@ parse_args() {
             --email) _need_value "$1" $#; EMAIL=$2; shift 2 ;;
             --version) _need_value "$1" $#; VERSION=$2; shift 2 ;;
             --repo) _need_value "$1" $#; REPO=$2; shift 2 ;;
+            --download-base) _need_value "$1" $#; ARG_DOWNLOAD_BASE=$2; shift 2 ;;
             --site-path) _need_value "$1" $#; ARG_SITE_PATH=$2; shift 2 ;;
             --listen-addr) _need_value "$1" $#; ARG_LISTEN_ADDR=$2; shift 2 ;;
             --no-caddy) NO_CADDY=1; shift ;;
@@ -181,6 +205,15 @@ parse_args() {
         _ph_err "invalid email '${EMAIL}'"; bad=1
     fi
     ((bad == 0)) || exit 2
+
+    # Download base (ADR 0036): resolve after REPO is validated; the flag
+    # wins over the environment variable. A custom (non-GitHub) base cannot
+    # resolve "latest" (that needs GitHub redirects), so mirror mode demands
+    # an explicit --version - fail closed, never guess.
+    DOWNLOAD_BASE=$(resolve_download_base "$REPO" "${ARG_DOWNLOAD_BASE:-${PROXYHUB_DOWNLOAD_BASE:-}}") || exit 2
+    if [[ $VERSION == latest && $DOWNLOAD_BASE != "$(default_download_base "$REPO")" ]]; then
+        _ph_die2 "custom download base requires an explicit --version (latest resolution needs GitHub)"
+    fi
 
     # The rehearsal seam only makes sense paired with --skip-dns-check;
     # refusing the lone form keeps it from becoming a lazy-production flag.
@@ -339,8 +372,17 @@ _validate_host_platform() {
         fi
         ((EUID == 0)) || _ph_fail "the installer must run as root (try: sudo bash install.sh ...)" || return 1
     fi
-    _curl -fsS --max-time 10 -o /dev/null "https://github.com" ||
-        _ph_fail "outbound HTTPS to github.com failed: the installer must reach GitHub releases (read-only check; nothing was modified)" || return 1
+    # Connectivity self-check follows the download base (ADR 0036): the
+    # official base still probes github.com; a custom base is probed itself.
+    local probe=https://github.com
+    [[ $DOWNLOAD_BASE == "$(default_download_base "$REPO")" ]] || probe=$DOWNLOAD_BASE
+    if ! _curl -fsS --max-time 10 -o /dev/null "$probe"; then
+        _ph_err "outbound HTTPS to ${probe} failed: the installer must reach the release download base (read-only check; nothing was modified)"
+        if [[ $probe == https://github.com ]]; then
+            _ph_err "if GitHub is unreachable from this host, point --download-base at a reachable mirror (see --help)"
+        fi
+        return 1
+    fi
     # --no-caddy: the operator brings their own reverse proxy, so neither a
     # local Caddy nor free 80/443 is required.
     if ((NO_CADDY == 0)); then
@@ -403,50 +445,10 @@ _generate_credentials() {
     [[ ${#ADMIN_PASSWORD} -ge 24 ]] || _ph_fail "generated admin password is too short"
 }
 
-# Download + verify (HTTPS verification is never disabled)
-_curl() { command curl "$@"; }
-_fetch() { _curl -fsSL --max-time 120 -o "$2" "$1" || _ph_fail "download failed: $1"; }
-
-_resolve_latest_tag() { # REPO -> stdout tag
-    local effective tag
-    effective=$(_curl -fsSIL --max-time 15 -o /dev/null -w '%{url_effective}' \
-        "https://github.com/$1/releases/latest") ||
-        _ph_fail "could not resolve the latest release of $1 (network error, or no stable release published yet)" || return 1
-    tag=${effective##*/}
-    if [[ -z $tag || $tag == latest ]] || ! validate_version "$tag" >/dev/null; then
-        _ph_fail "unexpected latest-release redirect for $1: '${effective}'"
-        return 1
-    fi
-    printf '%s' "$tag"
-}
-
-_download_and_verify() { # WORKDIR
-    local workdir=$1 asset base line_file="${1}/.checksum-line"
-    asset="proxyhub_${VERSION_TAG#v}_${DETECTED_OS}_${DETECTED_ARCH}.tar.gz"
-    base="https://github.com/${REPO}/releases/download/${VERSION_TAG}"
-
-    _ph_log "downloading ${base}/${asset}"
-    _fetch "${base}/SHA256SUMS" "${workdir}/SHA256SUMS" || return 1
-    _fetch "${base}/${asset}" "${workdir}/${asset}" || return 1
-
-    # Extract ONLY the matching checksum line; exactly one entry must exist.
-    grep -F -- "$asset" "${workdir}/SHA256SUMS" | grep -E '^[0-9a-fA-F]{64}[[:space:]]+[^[:space:]]+$' >"$line_file" || true
-    [[ $(wc -l <"$line_file" | tr -d ' ') == 1 ]] ||
-        _ph_fail "SHA256SUMS does not contain exactly one entry for ${asset} - refusing to install" || return 1
-
-    _ph_log "verifying SHA256 checksum of ${asset}"
-    if command -v sha256sum >/dev/null 2>&1; then
-        (cd "$workdir" && sha256sum -c "$line_file")
-    elif command -v shasum >/dev/null 2>&1; then
-        (cd "$workdir" && shasum -a 256 -c "$line_file")
-    else
-        _ph_fail "neither sha256sum nor shasum is available for checksum verification" || return 1
-    fi || _ph_fail "checksum verification FAILED for ${asset} - the download is corrupt or substituted; refusing to install" || return 1
-
-    mkdir -p "${workdir}/extract"
-    tar -xzf "${workdir}/${asset}" -C "${workdir}/extract" || _ph_fail "failed to unpack ${asset}" || return 1
-    [[ -f "${workdir}/extract/proxyhub" ]] || _ph_fail "${asset} does not contain the proxyhub binary"
-}
+# Download + verify (HTTPS verification is never disabled). The fetch
+# pipeline (SHA256SUMS + .minisig download, signature verification, checksum,
+# unpack) and latest-tag resolution live in lib.sh (fetch_release_and_verify,
+# _resolve_latest_tag) so `proxyhubctl update` walks the same chain (ADR 0036).
 
 # Install steps
 _write_config() {
@@ -685,9 +687,9 @@ _write_install_record() {
     # is only set in docker mode.
     local caddy_mode=$PROXYHUB_CADDY_MODE
     ((NO_CADDY == 0)) || caddy_mode=none
-    printf '# ProxyHub installation record - managed by install.sh, keep root-only.\nDOMAIN=%s\nSITE_PATH=%s\nREPO=%s\nVERSION=%s\nINSTALLED_AT=%s\nADMIN_USER=%s\nLISTEN_ADDR=%s\nNO_CADDY=%s\nCADDY_MODE=%s\nCADDY_CONTAINER=%s\n' \
+    printf '# ProxyHub installation record - managed by install.sh, keep root-only.\nDOMAIN=%s\nSITE_PATH=%s\nREPO=%s\nVERSION=%s\nINSTALLED_AT=%s\nADMIN_USER=%s\nLISTEN_ADDR=%s\nNO_CADDY=%s\nCADDY_MODE=%s\nCADDY_CONTAINER=%s\nDOWNLOAD_BASE=%s\n' \
         "$DOMAIN" "$SITE_PATH" "$REPO" "$VERSION_TAG" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-        "$ADMIN_USER" "$PROXYHUB_LISTEN_ADDR" "$NO_CADDY" "$caddy_mode" "$PROXYHUB_CADDY_CONTAINER" >"$rec" ||
+        "$ADMIN_USER" "$PROXYHUB_LISTEN_ADDR" "$NO_CADDY" "$caddy_mode" "$PROXYHUB_CADDY_CONTAINER" "$DOWNLOAD_BASE" >"$rec" ||
         _ph_fail "failed to write ${rec}" || return 1
     chmod 0600 "$rec" || _ph_fail "failed to chmod ${rec}" || return 1
     _ph_log "wrote ${rec} (mode 0600)"
@@ -732,7 +734,9 @@ main() {
 
     TIMESTAMP=$(date -u +%Y%m%d%H%M%S)
     WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/proxyhub-install.XXXXXX") || _die "cannot create a temporary workspace"
-    _download_and_verify "$WORKDIR" || _die "release download or checksum verification failed"
+    fetch_release_and_verify "$WORKDIR" "$DOWNLOAD_BASE" "$VERSION_TAG" \
+        "proxyhub_${VERSION_TAG#v}_${DETECTED_OS}_${DETECTED_ARCH}.tar.gz" ||
+        _die "release download or signature/checksum verification failed"
     if ! mkdir -p "$(dirname "$(root_path "$PROXYHUB_BINARY")")" ||
         ! install -m 0755 "${WORKDIR}/extract/proxyhub" "$(root_path "$PROXYHUB_BINARY")"; then
         _die "failed to install $(root_path "$PROXYHUB_BINARY")"
@@ -749,9 +753,12 @@ main() {
             _PH_LIB_TMP=$(mktemp -d)
             chmod 700 "$_PH_LIB_TMP"
         fi
-        _ph_ctl_url="${PROXYHUB_CTL_URL:-https://raw.githubusercontent.com/taliove/proxyhub/main/scripts/install/proxyhubctl}"
-        curl -fsSL "$_ph_ctl_url" -o "$_PH_LIB_TMP/proxyhubctl" ||
-            _die "failed to download proxyhubctl from ${_ph_ctl_url}"
+        # Same source candidates as the companion lib (ADR 0036): explicit
+        # PROXYHUB_CTL_URL first, then jsDelivr, then raw.githubusercontent.
+        fetch_first_ok "$_PH_LIB_TMP/proxyhubctl" "${PROXYHUB_CTL_URL:-}" \
+            "https://cdn.jsdelivr.net/gh/taliove/proxyhub@main/scripts/install/proxyhubctl" \
+            "https://raw.githubusercontent.com/taliove/proxyhub/main/scripts/install/proxyhubctl" ||
+            _die "failed to download proxyhubctl from every source"
         _ph_ctl="$_PH_LIB_TMP/proxyhubctl"
     fi
     install -m 0755 "$_ph_ctl" \

--- a/install.sh
+++ b/install.sh
@@ -374,9 +374,13 @@ _validate_host_platform() {
     fi
     # Connectivity self-check follows the download base (ADR 0036): the
     # official base still probes github.com; a custom base is probed itself.
+    # No -f: the probe proves TRANSPORT reachability only. A bare mirror
+    # base (ghproxy prefix, nginx reverse proxy) commonly answers 404 while
+    # serving the artifacts fine, so any HTTP response counts as reachable;
+    # only a transport failure (DNS/connect/TLS) fails the check.
     local probe=https://github.com
     [[ $DOWNLOAD_BASE == "$(default_download_base "$REPO")" ]] || probe=$DOWNLOAD_BASE
-    if ! _curl -fsS --max-time 10 -o /dev/null "$probe"; then
+    if ! _curl -sS --max-time 10 -o /dev/null "$probe"; then
         _ph_err "outbound HTTPS to ${probe} failed: the installer must reach the release download base (read-only check; nothing was modified)"
         if [[ $probe == https://github.com ]]; then
             _ph_err "if GitHub is unreachable from this host, point --download-base at a reachable mirror (see --help)"

--- a/scripts/install/ACCEPTANCE.md
+++ b/scripts/install/ACCEPTANCE.md
@@ -507,10 +507,79 @@
 
 ---
 
+## 测试 14: 制品签名验证（验签负例）
+
+### 前置条件
+- [ ] 全新 Ubuntu 22.04 服务器（未安装 ProxyHub）
+- [ ] 一个可控的 HTTPS 静态文件服务（如 nginx / caddy file_server），托管一份从 GitHub releases 下载的某版本制品目录（tarball + SHA256SUMS + SHA256SUMS.minisig）
+
+### 步骤
+1. 篡改镜像目录里的 `SHA256SUMS`（改动任意一行哈希），保留原 `SHA256SUMS.minisig`
+2. 以该目录为下载基运行安装：
+   ```bash
+   bash install.sh \
+     --non-interactive \
+     --domain test14.example.com \
+     --version <对应版本> \
+     --download-base https://<你的验收镜像>
+   ```
+3. 观察安装器在验签阶段的行为
+4. 恢复 SHA256SUMS，改为删除 `SHA256SUMS.minisig`（模拟镜像不转发签名文件），重跑安装
+
+### 通过标准
+- [ ] 篡改 SHA256SUMS 时：安装器在验签阶段报错退出（exit code 非 0），错误信息指明签名校验失败
+- [ ] 缺 SHA256SUMS.minisig 时：安装器同样 fail closed，错误信息指明缺签名文件
+- [ ] 两种负例下 `/usr/local/bin/proxyhub` 均未被写入（`ls /usr/local/bin/proxyhub` 报不存在）
+- [ ] 恢复完整制品目录后重跑，安装成功（签名链正例走通）
+
+### 失败标准
+- 篡改或缺签名时安装仍继续或成功
+- 报错文案未指明签名问题（运维无法定位原因）
+
+---
+
+## 测试 15: 镜像模式安装（--download-base 正例 + latest 负例）
+
+### 前置条件
+- [ ] 全新 Ubuntu 22.04 服务器（未安装 ProxyHub）
+- [ ] 一个当前可达的镜像下载基（ghproxy 前缀型或自建反代），先用 `curl -fsSI <base>/<version>/SHA256SUMS.minisig` 自查签名文件可达
+- [ ] DNS A 记录已指向服务器 IP
+
+### 步骤
+1. 负例先行——镜像下载基 + latest（缺省版本）：
+   ```bash
+   bash install.sh \
+     --non-interactive \
+     --domain test15.example.com \
+     --download-base https://<镜像>/taliove/proxyhub/releases/download
+   ```
+2. 正例——镜像下载基 + 显式版本：
+   ```bash
+   bash install.sh \
+     --non-interactive \
+     --domain test15.example.com \
+     --version <已发布版本> \
+     --download-base https://<镜像>/taliove/proxyhub/releases/download
+   ```
+3. 检查安装档案与日志
+
+### 通过标准
+- [ ] latest 负例：安装器拒绝，exit code 2，错误信息提示镜像下载基必须显式 `--version`；未写任何文件
+- [ ] 正例安装成功，`https://<domain>/<site-path>/health` 返回 200 OK
+- [ ] `/root/.proxyhub-install-info` 含 `DOWNLOAD_BASE=<镜像base>` 字段
+- [ ] 安装日志显示制品 URL 取自镜像 base 而非 github.com
+
+### 失败标准
+- latest + 镜像下载基被放行或静默回退到其他源
+- 安装档案缺 DOWNLOAD_BASE 字段
+- 制品实际仍从 github.com 下载
+
+---
+
 ## 验收决策
 
 ### 通过标准（全部满足）
-- [ ] 测试 1-13 全部通过
+- [ ] 测试 1-15 全部通过
 - [ ] 无 CRITICAL 或 HIGH 优先级 bug
 - [ ] 文档完整（DEPLOY.md + SECURITY.md）
 - [ ] 安装器和 proxyhubctl 帮助文档准确
@@ -551,6 +620,8 @@ ProxyHub 版本： _______________
 | 11 | 重新安装 | ☐ PASS ☐ FAIL | |
 | 12 | Docker Caddy 模式（host 网络） | ☐ PASS ☐ FAIL | |
 | 13 | Docker Caddy 模式（桥接网络） | ☐ PASS ☐ FAIL | |
+| 14 | 制品签名验证（验签负例） | ☐ PASS ☐ FAIL | |
+| 15 | 镜像模式安装 | ☐ PASS ☐ FAIL | |
 
 **最终决策**： ☐ 批准发布 0.1.0  ☐ 需要修复后重测
 

--- a/scripts/install/lib.sh
+++ b/scripts/install/lib.sh
@@ -60,6 +60,15 @@ PROXYHUB_DOCKER_NETMODE="${PROXYHUB_DOCKER_NETMODE:-}"
 PROXYHUB_BRIDGE_GATEWAY="${PROXYHUB_BRIDGE_GATEWAY:-}"
 PROXYHUB_BRIDGE_SUBNET="${PROXYHUB_BRIDGE_SUBNET:-}"
 
+# Release-signing public key (minisign text format: base64 of "Ed" ||
+# 8-byte keynum || 32-byte raw Ed25519 key), the trust anchor for release
+# artifacts (ADR 0036). The private key lives only in GitHub Secrets
+# (MINISIGN_PRIVATE_KEY); rotation = generate a new pair, swap this constant,
+# ship a new release. Defined once here: install.sh and proxyhubctl both
+# source this library, so the constant travels with whichever copy of
+# lib.sh (or the installed proxyhubctl-lib.sh) they load.
+readonly PROXYHUB_MINISIGN_PUBKEY="RWQHrp6zfJDEQ0TWFXc5k3iL1ZhIADchbbRKuEIIzFaSvtfKD8Gmf/Lg"
+
 # --------------------------------------------------------------------------
 # Output helpers
 # --------------------------------------------------------------------------
@@ -187,6 +196,72 @@ random_token() {
     # once head closes the pipe, so tolerate that under pipefail.
     token=$(LC_ALL=C tr -dc 'A-Za-z0-9_-' < /dev/urandom 2>/dev/null | head -c "$n") || true
     printf '%s' "$token"
+}
+
+# --------------------------------------------------------------------------
+# Release signature verification (ADR 0036)
+# --------------------------------------------------------------------------
+
+# verify_minisig FILE MINISIG_FILE [PUBKEY_B64] - verify a minisign signature
+# over FILE with openssl only (no minisign dependency on the target host).
+# PUBKEY_B64 defaults to the embedded release key PROXYHUB_MINISIGN_PUBKEY;
+# the parameter exists so tests can pass a synthetic key. Fails closed with a
+# distinct error for each case: missing FILE or MINISIG_FILE, malformed
+# signature, unavailable openssl, verification failure.
+verify_minisig() {
+    local file=$1 minisig=$2 pubkey_b64=${3:-${PROXYHUB_MINISIGN_PUBKEY:-}}
+    if ! command -v openssl >/dev/null 2>&1; then
+        _ph_err "openssl is required to verify release signatures but was not found"
+        return 1
+    fi
+    if [[ ! -f $file ]]; then
+        _ph_err "file to verify not found: ${file}"
+        return 1
+    fi
+    if [[ ! -f $minisig ]]; then
+        _ph_err "signature file missing: ${minisig} - refusing to trust unverified artifacts"
+        return 1
+    fi
+    if [[ -z $pubkey_b64 ]]; then
+        _ph_err "no minisign public key configured"
+        return 1
+    fi
+    local tmpdir rc=0
+    tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/proxyhub-verify.XXXXXX") || return 1
+    _verify_minisig_in "$tmpdir" "$file" "$minisig" "$pubkey_b64" || rc=$?
+    rm -rf "$tmpdir"
+    return "$rc"
+}
+
+# _verify_minisig_in TMPDIR FILE MINISIG_FILE PUBKEY_B64 - worker for
+# verify_minisig, operating inside an already-created scratch directory.
+# MINISIG_FILE line 2 is base64 of exactly 74 bytes: "Ed" || 8-byte keynum ||
+# 64-byte Ed25519 signature (legacy, non-prehashed minisign format). The
+# public key decodes to 42 bytes ("Ed" || keynum || 32-byte raw key), from
+# which an Ed25519 SPKI DER key is rebuilt for `openssl pkeyutl`.
+_verify_minisig_in() {
+    local tmpdir=$1 file=$2 minisig=$3 pubkey_b64=$4
+    if ! sed -n '2p' "$minisig" | base64 -d >"$tmpdir/sig.raw" 2>/dev/null \
+        || [[ $(wc -c <"$tmpdir/sig.raw") -ne 74 ]] \
+        || [[ $(head -c 2 "$tmpdir/sig.raw") != Ed ]]; then
+        _ph_err "malformed signature file ${minisig} (expected a minisign legacy Ed25519 signature)"
+        return 1
+    fi
+    tail -c 64 "$tmpdir/sig.raw" >"$tmpdir/sig.bin"
+    if ! printf '%s' "$pubkey_b64" | base64 -d >"$tmpdir/key.raw" 2>/dev/null \
+        || [[ $(wc -c <"$tmpdir/key.raw") -ne 42 ]]; then
+        _ph_err "configured minisign public key is malformed"
+        return 1
+    fi
+    # Rebuild Ed25519 SPKI DER: fixed 12-byte prefix + 32-byte raw key.
+    printf '\x30\x2a\x30\x05\x06\x03\x2b\x65\x70\x03\x21\x00' >"$tmpdir/key.der"
+    tail -c 32 "$tmpdir/key.raw" >>"$tmpdir/key.der"
+    if ! openssl pkeyutl -verify -pubin -inkey "$tmpdir/key.der" -keyform DER \
+        -rawin -in "$file" -sigfile "$tmpdir/sig.bin" >/dev/null 2>&1; then
+        _ph_err "signature verification FAILED for ${file} - refusing to trust this download"
+        return 1
+    fi
+    _ph_log "signature verified: ${file}"
 }
 
 # --------------------------------------------------------------------------

--- a/scripts/install/lib.sh
+++ b/scripts/install/lib.sh
@@ -66,8 +66,10 @@ PROXYHUB_BRIDGE_SUBNET="${PROXYHUB_BRIDGE_SUBNET:-}"
 # (MINISIGN_PRIVATE_KEY); rotation = generate a new pair, swap this constant,
 # ship a new release. Defined once here: install.sh and proxyhubctl both
 # source this library, so the constant travels with whichever copy of
-# lib.sh (or the installed proxyhubctl-lib.sh) they load.
-readonly PROXYHUB_MINISIGN_PUBKEY="RWQHrp6zfJDEQ0TWFXc5k3iL1ZhIADchbbRKuEIIzFaSvtfKD8Gmf/Lg"
+# lib.sh (or the installed proxyhubctl-lib.sh) they load. NOT readonly:
+# tests substitute a synthetic throwaway keypair per subshell (same seam
+# pattern as PROXYHUB_LISTEN_ADDR); production code never overrides it.
+PROXYHUB_MINISIGN_PUBKEY="${PROXYHUB_MINISIGN_PUBKEY:-RWQHrp6zfJDEQ0TWFXc5k3iL1ZhIADchbbRKuEIIzFaSvtfKD8Gmf/Lg}"
 
 # --------------------------------------------------------------------------
 # Output helpers
@@ -76,6 +78,13 @@ readonly PROXYHUB_MINISIGN_PUBKEY="RWQHrp6zfJDEQ0TWFXc5k3iL1ZhIADchbbRKuEIIzFaSv
 # _ph_err MSG... - print an error line to stderr with the [proxyhub] prefix.
 _ph_err() {
     printf '[proxyhub] %s\n' "$*" >&2
+}
+
+# _ph_fail MSG... - print each MSG as an error line and return 1.
+_ph_fail() {
+    local _m
+    for _m in "$@"; do _ph_err "$_m"; done
+    return 1
 }
 
 # _ph_log MSG... - print an informational line to stderr.
@@ -262,6 +271,139 @@ _verify_minisig_in() {
         return 1
     fi
     _ph_log "signature verified: ${file}"
+}
+
+# --------------------------------------------------------------------------
+# Download base and release fetch (ADR 0036)
+# --------------------------------------------------------------------------
+
+# default_download_base REPO - print the official GitHub releases download
+# base for REPO. The base is tag-independent: per-release URLs append
+# "/<version-tag>/<asset>" (release_asset_url).
+default_download_base() {
+    printf 'https://github.com/%s/releases/download' "$1"
+}
+
+# release_asset_url BASE VERSION_TAG NAME - print the download URL of a
+# release asset derived from a download base.
+release_asset_url() {
+    printf '%s/%s/%s' "$1" "$2" "$3"
+}
+
+# resolve_download_base REPO [CUSTOM] - print the effective download base:
+# CUSTOM (trailing slashes stripped) when given, else the official GitHub
+# base. CUSTOM must be an https:// URL: the release signature anchors
+# artifact trust, but plaintext transport is still refused outright.
+resolve_download_base() {
+    local repo=$1 custom=${2:-}
+    if [[ -z $custom ]]; then
+        default_download_base "$repo"
+        return 0
+    fi
+    while [[ $custom == */ ]]; do custom=${custom%/}; done
+    if [[ $custom != https://* ]]; then
+        _ph_err "download base must use https:// (got '${custom}')"
+        return 1
+    fi
+    printf '%s' "$custom"
+}
+
+# fetch_first_ok DEST OVERRIDE CANDIDATES... - download to DEST. An explicit
+# OVERRIDE wins over everything and never falls through to the built-in
+# candidates (no silent fallback); without an override each candidate is
+# tried in order and only a total failure is an error. Used for the
+# companion files (lib.sh, proxyhubctl), which carry no trust - the release
+# signature is the trust anchor, transport is CDN HTTPS either way.
+fetch_first_ok() {
+    local dest=$1 override=${2:-} url
+    shift 2 || return 1
+    if [[ -n $override ]]; then
+        if curl -fsSL "$override" -o "$dest"; then return 0; fi
+        _ph_err "download failed: ${override} (explicit override; built-in candidates not tried)"
+        return 1
+    fi
+    for url in "$@"; do
+        if curl -fsSL "$url" -o "$dest" 2>/dev/null; then
+            _ph_log "downloaded ${url}"
+            return 0
+        fi
+        _ph_err "download candidate failed, trying next source: ${url}"
+    done
+    _ph_err "all download candidates failed for ${dest##*/}"
+    return 1
+}
+
+# _curl ARGS... - curl wrapper seam; tests override it to mock the network.
+_curl() { command curl "$@"; }
+
+# _fetch URL DEST - download URL to DEST (HTTPS verification never disabled).
+_fetch() {
+    _curl -fsSL --max-time 120 -o "$2" "$1" && return 0
+    _ph_err "download failed: $1"
+    return 1
+}
+
+# _resolve_latest_tag REPO -> stdout tag. Latest resolution is anchored on
+# GitHub redirects BY DESIGN (ADR 0036): mirrors cannot reliably proxy it,
+# which is why a custom download base requires an explicit --version instead.
+_resolve_latest_tag() { # REPO -> stdout tag
+    local effective tag
+    effective=$(_curl -fsSIL --max-time 15 -o /dev/null -w '%{url_effective}' \
+        "https://github.com/$1/releases/latest") ||
+        _ph_fail "could not resolve the latest release of $1 (network error, or no stable release published yet)" || return 1
+    tag=${effective##*/}
+    if [[ -z $tag || $tag == latest ]] || ! validate_version "$tag" >/dev/null; then
+        _ph_fail "unexpected latest-release redirect for $1: '${effective}'"
+        return 1
+    fi
+    printf '%s' "$tag"
+}
+
+# fetch_release_and_verify WORKDIR DOWNLOAD_BASE VERSION_TAG ASSET - download
+# SHA256SUMS, SHA256SUMS.minisig and ASSET from DOWNLOAD_BASE/VERSION_TAG,
+# then verify IN ORDER: the minisign signature over SHA256SUMS (the trust
+# anchor, ADR 0036), then ASSET's checksum against the signed SHA256SUMS,
+# then unpack. Every step fails closed: a missing .minisig, a malformed or
+# failing signature, or a checksum mismatch refuses the download before any
+# binary lands on the host.
+fetch_release_and_verify() {
+    local workdir=$1 base="${2}/${3}" asset=$4 line_file="${1}/.checksum-line"
+
+    _ph_log "downloading ${base}/${asset}"
+    _fetch "${base}/SHA256SUMS" "${workdir}/SHA256SUMS" || return 1
+    _fetch "${base}/SHA256SUMS.minisig" "${workdir}/SHA256SUMS.minisig" || return 1
+    verify_minisig "${workdir}/SHA256SUMS" "${workdir}/SHA256SUMS.minisig" || return 1
+    _fetch "${base}/${asset}" "${workdir}/${asset}" || return 1
+
+    # Extract ONLY the matching checksum line; exactly one entry must exist.
+    grep -F -- "$asset" "${workdir}/SHA256SUMS" | grep -E '^[0-9a-fA-F]{64}[[:space:]]+[^[:space:]]+$' >"$line_file" || true
+    if [[ $(wc -l <"$line_file" | tr -d ' ') != 1 ]]; then
+        _ph_err "SHA256SUMS does not contain exactly one entry for ${asset} - refusing to install"
+        return 1
+    fi
+
+    _ph_log "verifying SHA256 checksum of ${asset}"
+    if command -v sha256sum >/dev/null 2>&1; then
+        (cd "$workdir" && sha256sum -c "$line_file")
+    elif command -v shasum >/dev/null 2>&1; then
+        (cd "$workdir" && shasum -a 256 -c "$line_file")
+    else
+        _ph_err "neither sha256sum nor shasum is available for checksum verification"
+        return 1
+    fi || {
+        _ph_err "checksum verification FAILED for ${asset} - the download is corrupt or substituted; refusing to install"
+        return 1
+    }
+
+    mkdir -p "${workdir}/extract"
+    if ! tar -xzf "${workdir}/${asset}" -C "${workdir}/extract"; then
+        _ph_err "failed to unpack ${asset}"
+        return 1
+    fi
+    [[ -f "${workdir}/extract/proxyhub" ]] || {
+        _ph_err "${asset} does not contain the proxyhub binary"
+        return 1
+    }
 }
 
 # --------------------------------------------------------------------------

--- a/scripts/install/lib.sh
+++ b/scripts/install/lib.sh
@@ -66,10 +66,14 @@ PROXYHUB_BRIDGE_SUBNET="${PROXYHUB_BRIDGE_SUBNET:-}"
 # (MINISIGN_PRIVATE_KEY); rotation = generate a new pair, swap this constant,
 # ship a new release. Defined once here: install.sh and proxyhubctl both
 # source this library, so the constant travels with whichever copy of
-# lib.sh (or the installed proxyhubctl-lib.sh) they load. NOT readonly:
-# tests substitute a synthetic throwaway keypair per subshell (same seam
-# pattern as PROXYHUB_LISTEN_ADDR); production code never overrides it.
-PROXYHUB_MINISIGN_PUBKEY="${PROXYHUB_MINISIGN_PUBKEY:-RWQHrp6zfJDEQ0TWFXc5k3iL1ZhIADchbbRKuEIIzFaSvtfKD8Gmf/Lg}"
+# lib.sh (or the installed proxyhubctl-lib.sh) they load. Overridable ONLY
+# in PROXYHUB_ROOT test mode (synthetic fixture keys): in production the
+# trust anchor must never be swappable via the environment.
+if [[ -n ${PROXYHUB_ROOT:-} ]]; then
+    PROXYHUB_MINISIGN_PUBKEY="${PROXYHUB_MINISIGN_PUBKEY:-RWQHrp6zfJDEQ0TWFXc5k3iL1ZhIADchbbRKuEIIzFaSvtfKD8Gmf/Lg}"
+else
+    PROXYHUB_MINISIGN_PUBKEY="RWQHrp6zfJDEQ0TWFXc5k3iL1ZhIADchbbRKuEIIzFaSvtfKD8Gmf/Lg"
+fi
 
 # --------------------------------------------------------------------------
 # Output helpers
@@ -318,6 +322,13 @@ fetch_first_ok() {
     local dest=$1 override=${2:-} url
     shift 2 || return 1
     if [[ -n $override ]]; then
+        # The override names code executed as root (lib.sh / proxyhubctl);
+        # plaintext transports are refused, mirroring the PROXYHUB_LIB_URL
+        # guard in install.sh (test mode keeps file:// for fixtures).
+        if [[ $override != https://* && -z ${PROXYHUB_ROOT:-} ]]; then
+            _ph_err "override URL must use https:// (got ${override}) - refusing to fetch code over a plaintext transport"
+            return 1
+        fi
         if curl -fsSL "$override" -o "$dest"; then return 0; fi
         _ph_err "download failed: ${override} (explicit override; built-in candidates not tried)"
         return 1

--- a/scripts/install/proxyhubctl
+++ b/scripts/install/proxyhubctl
@@ -10,6 +10,7 @@
 #   proxyhubctl restart
 #   proxyhubctl show-info
 #   proxyhubctl update [VERSION] [--yes] [--prerelease] [--stable-only]
+#                      [--download-base URL]
 #   proxyhubctl backup [--protect]
 #   proxyhubctl restore ARCHIVE [--yes]
 #   proxyhubctl reset-mfa --username NAME [--yes]
@@ -622,11 +623,14 @@ _detect_os_arch() {
 }
 
 # cmd_update [VERSION] [--version VERSION] [--yes] [--prerelease] [--stable-only]
-# Guarded update: backup first, download + SHA256 verify, swap the binary,
-# verify the retained-state fingerprint with the new binary, restart; roll
-# back to the previous binary on any failure after the swap.
+#            [--download-base URL]
+# Guarded update: backup first, download + minisign signature + SHA256
+# double-gate verification (ADR 0036), swap the binary, verify the
+# retained-state fingerprint with the new binary, restart; roll back to the
+# previous binary on any failure after the swap.
 cmd_update() {
     local target="" confirmed=0 allow_prerelease=0 stable_only=0
+    local download_base_arg=""
     while (( $# > 0 )); do
         case "$1" in
             --yes) confirmed=1; shift ;;
@@ -635,6 +639,10 @@ cmd_update() {
             --version)
                 (( $# >= 2 )) || { _ph_err "--version requires a value"; return 2; }
                 target="$2"; shift 2 ;;
+            --download-base)
+                (( $# >= 2 )) || { _ph_err "--download-base requires a value"; return 2; }
+                download_base_arg="$2"; shift 2 ;;
+            --download-base=*) download_base_arg="${1#--download-base=}"; shift ;;
             -*) _ph_err "unknown option: $1"; return 2 ;;
             *) target="$1"; shift ;;
         esac
@@ -653,6 +661,27 @@ cmd_update() {
     if [[ -z "$current_version" ]]; then
         _ph_err "failed to read current VERSION from ${install_info}"
         return 1
+    fi
+
+    # Effective download base (ADR 0036): an explicit --download-base wins
+    # over the install record's DOWNLOAD_BASE; records predating the field
+    # fall back to the official GitHub releases base. An invalid flag value
+    # is a usage error (rc 2); a corrupt record value is an operational
+    # failure (rc 1).
+    local record_base download_base
+    record_base=$(_read_install_field DOWNLOAD_BASE)
+    if [[ -n $download_base_arg ]]; then
+        download_base=$(resolve_download_base "$repo" "$download_base_arg") || return 2
+    else
+        download_base=$(resolve_download_base "$repo" "$record_base") || return 1
+    fi
+
+    # Mirror version discipline: latest resolution is anchored on GitHub
+    # (ADR 0036) and mirrors cannot reliably proxy it, so a custom download
+    # base requires an explicit version (same wording as install.sh).
+    if [[ -z $target && $download_base != "$(default_download_base "$repo")" ]]; then
+        _ph_err "custom download base requires an explicit --version (latest resolution needs GitHub)"
+        return 2
     fi
 
     # Resolve the target version: explicit argument, or the latest release.
@@ -719,7 +748,7 @@ cmd_update() {
     arch="${os_arch#* }"
     # Asset naming must match scripts/release/package.sh (underscores).
     local asset="proxyhub_${target#v}_${os}_${arch}.tar.gz"
-    local base="https://github.com/${repo}/releases/download/${target}"
+    local base="${download_base}/${target}"
 
     local workdir
     workdir=$(mktemp -d) || {
@@ -733,6 +762,15 @@ cmd_update() {
         _ph_err "failed to download SHA256SUMS for ${target}"
         return 1
     fi
+    # Signature trust anchor (ADR 0036): verify the minisign signature over
+    # SHA256SUMS before trusting any checksum in it. A missing or failing
+    # signature refuses the download here, before the live binary is touched
+    # (the pre-update backup rollback path is never reached).
+    if ! curl -fsSL --max-time 60 -o "${workdir}/SHA256SUMS.minisig" "${base}/SHA256SUMS.minisig"; then
+        _ph_err "failed to download SHA256SUMS.minisig for ${target}; refusing to update (current installation untouched)"
+        return 1
+    fi
+    verify_minisig "${workdir}/SHA256SUMS" "${workdir}/SHA256SUMS.minisig" || return 1
     if ! curl -fsSL --max-time 300 -o "${workdir}/${asset}" "${base}/${asset}"; then
         _ph_err "failed to download ${asset}"
         return 1
@@ -1160,10 +1198,19 @@ cmd_status() {
     site_path=$(_read_install_field SITE_PATH)
     version=$(_read_install_field VERSION)
 
+    # Effective download base (ADR 0036): the recorded DOWNLOAD_BASE, or the
+    # official GitHub releases base for records predating the field.
+    local repo download_base
+    repo=$(_read_install_field REPO)
+    repo="${repo:-taliove/proxyhub}"
+    download_base=$(_read_install_field DOWNLOAD_BASE)
+    download_base="${download_base:-$(default_download_base "$repo")}"
+
     printf 'ProxyHub Status\n'
     printf '===============\n'
     printf 'Service state: %s\n' "$state"
     printf 'Version:       %s\n' "${version:-unknown}"
+    printf 'Download base: %s\n' "$download_base"
     if [[ -n "$domain" ]] && [[ -n "$site_path" ]]; then
         printf 'Management URL: https://%s/%s/\n' "$domain" "$site_path"
     else
@@ -1234,9 +1281,12 @@ Commands:
   backup [--protect]  Create a timestamped backup
   restore ARCHIVE [--yes]
                       Restore from a backup archive
-  update [VERSION] [--yes] [--prerelease] [--stable-only]
-                      Guarded update: backup, checksum + state-fingerprint
-                      verification, automatic rollback on failure
+  update [VERSION] [--yes] [--prerelease] [--stable-only] [--download-base URL]
+                      Guarded update: backup, signature + checksum +
+                      state-fingerprint verification, automatic rollback on
+                      failure. Downloads follow the install record's
+                      DOWNLOAD_BASE; --download-base overrides it (a custom
+                      base requires an explicit VERSION)
   rotate-path [PATH] [--yes]
                       Rotate to a new Site Path (high-risk, requires --yes)
   reset-mfa --username NAME [--yes]
@@ -1252,6 +1302,8 @@ Options:
   --yes               Skip confirmation prompts (required for high-risk ops)
   --prerelease        With update: allow installing a prerelease version
   --stable-only       With update: reject prereleases (used by auto-update)
+  --download-base URL With update: mirror download base (overrides the
+                      install record's DOWNLOAD_BASE; https:// only)
   --purge             With uninstall: also remove state and backups
   --username NAME     With reset-mfa: the account to reset
 EOF

--- a/scripts/install/test_install.sh
+++ b/scripts/install/test_install.sh
@@ -67,6 +67,18 @@ trap _cleanup_dirs EXIT
 # Sandbox + mock builders (used inside subshells)
 # --------------------------------------------------------------------------
 
+# sign_fixture_sums PRIVKEY_PEM SUMS_FILE - (re)sign a fixture SHA256SUMS in
+# minisign text format (line 2 = base64("Ed" || 8-byte keynum || signature)).
+sign_fixture_sums() {
+    openssl pkeyutl -sign -inkey "$1" -rawin -in "$2" -out "$2.sigbin" 2>/dev/null
+    {
+        printf 'untrusted comment: signature from synthetic test key\n'
+        { printf 'Ed'; head -c 8 /dev/zero; cat "$2.sigbin"; } | base64 | tr -d '\n'
+        printf '\n'
+    } >"$2.minisig"
+    rm -f "$2.sigbin"
+}
+
 # setup_sandbox - create PROXYHUB_ROOT with a supported /etc/os-release and a
 # fixture release (fake binary tarball + SHA256SUMS with a decoy entry).
 setup_sandbox() {
@@ -105,6 +117,17 @@ EOF
                 "proxyhub_9.9.9_linux_arm64.tar.gz"
         } >SHA256SUMS
     )
+    # Synthetic throwaway Ed25519 keypair for the signature trust chain (ADR
+    # 0036): every install-path test passes REAL signature verification
+    # against this key. PROXYHUB_MINISIGN_PUBKEY is substituted only inside
+    # this subshell; the production constant in lib.sh stays untouched.
+    openssl genpkey -algorithm ed25519 -out "$FIX_DIR/testkey.pem" 2>/dev/null
+    openssl pkey -in "$FIX_DIR/testkey.pem" -pubout -outform DER 2>/dev/null |
+        tail -c 32 >"$FIX_DIR/testkey.raw"
+    PROXYHUB_MINISIGN_PUBKEY=$(
+        { printf 'Ed'; head -c 8 /dev/zero; cat "$FIX_DIR/testkey.raw"; } | base64 | tr -d '\n'
+    )
+    sign_fixture_sums "$FIX_DIR/testkey.pem" "$FIX_DIR/SHA256SUMS"
 }
 
 # mock_host - override every host/network seam. Defines functions; call inside
@@ -131,6 +154,7 @@ mock_host() {
             return 0
         fi
         case $url in
+            *.minisig) cp "$FIX_DIR/SHA256SUMS.minisig" "$out" ;;
             */SHA256SUMS) cp "$FIX_DIR/SHA256SUMS" "$out" ;;
             *.tar.gz) cp "$FIX_DIR/$TEST_ASSET" "$out" ;;
             *) : ;;
@@ -844,6 +868,266 @@ if ! env -i PATH=/usr/bin:/bin bash -c 'command -v caddy' >/dev/null 2>&1; then
 else
     printf 'SKIP: caddy present on base PATH; skipping caddy-missing test\n'
 fi
+
+# --------------------------------------------------------------------------
+# Download base (ADR 0036): parsing, precedence, https and latest discipline
+# --------------------------------------------------------------------------
+
+# --help documents the new flag.
+[[ $help_out == *"--download-base"* ]] && _pass || _fail "--help missing [--download-base]"
+
+# Default base derives from --repo (GitHub official releases).
+db=$(parse_args --non-interactive --domain example.com >/dev/null 2>&1 && printf '%s' "$DOWNLOAD_BASE")
+_assert_eq "https://github.com/taliove/proxyhub/releases/download" "$db" "default download base"
+
+# The flag wins over the environment variable; trailing slashes are stripped.
+db=$(PROXYHUB_DOWNLOAD_BASE="https://env-mirror.example.com/dl" parse_args \
+    --non-interactive --domain example.com --version 9.9.9 \
+    --download-base "https://flag-mirror.example.com/dl/" >/dev/null 2>&1 && printf '%s' "$DOWNLOAD_BASE")
+_assert_eq "https://flag-mirror.example.com/dl" "$db" "flag wins over env; trailing slash stripped"
+
+# The environment variable supplies the base when the flag is absent.
+db=$(PROXYHUB_DOWNLOAD_BASE="https://env-mirror.example.com/dl" parse_args \
+    --non-interactive --domain example.com --version 9.9.9 >/dev/null 2>&1 && printf '%s' "$DOWNLOAD_BASE")
+_assert_eq "https://env-mirror.example.com/dl" "$db" "env download base"
+
+# Non-https bases are usage errors (exit 2), via flag or env.
+_assert_rc 2 "non-https --download-base" main --non-interactive --domain example.com \
+    --download-base "http://mirror.example.com/dl"
+rc=0
+( PROXYHUB_DOWNLOAD_BASE="http://mirror.example.com/dl" main --non-interactive --domain example.com ) >/dev/null 2>&1 || rc=$?
+_assert_eq 2 "$rc" "non-https env download base"
+
+# Mirror mode + --version latest fails closed with explicit-version guidance.
+ml=$(
+    rc=0
+    out=$(main --non-interactive --domain example.com \
+        --download-base "https://mirror.example.com/dl" 2>&1) || rc=$?
+    printf 'RC=%d\n%s\n' "$rc" "$out"
+)
+[[ $ml == *"RC=2"* ]] && _pass || _fail "mirror + latest did not exit 2: $ml"
+[[ $ml == *"custom download base requires an explicit --version"* ]] && _pass ||
+    _fail "mirror + latest guidance missing: $ml"
+
+# --------------------------------------------------------------------------
+# Download base flow-through: probe + artifact URLs derive from the base
+# --------------------------------------------------------------------------
+
+# Custom mirror base: the probe hits the base itself, every artifact URL
+# resolves under it, github.com is never touched, the record carries the
+# base, and real signature verification passes end to end.
+mirror=$(
+    setup_sandbox
+    mock_host
+    export CURL_CALLS="$SBX/curl.calls"
+    rc=0
+    ( main --non-interactive --domain proxy.example.com --version 9.9.9 \
+        --download-base "https://mirror.example.com/dl" \
+        >"$SBX/stdout.log" 2>"$SBX/stderr.log" ) || rc=$?
+    printf 'RC=%d\nSBX=%s\n' "$rc" "$SBX"
+)
+mirror_rc=$(printf '%s\n' "$mirror" | sed -n 's/^RC=//p')
+MIR_SBX=$(printf '%s\n' "$mirror" | sed -n 's/^SBX=//p')
+TEST_DIRS+=("$MIR_SBX")
+
+_assert_eq 0 "$mirror_rc" "mirror download base install exit code"
+_assert_file_contains "$MIR_SBX/curl.calls" "https://mirror.example.com/dl"
+_assert_file_contains "$MIR_SBX/curl.calls" "https://mirror.example.com/dl/v9.9.9/SHA256SUMS"
+_assert_file_contains "$MIR_SBX/curl.calls" "https://mirror.example.com/dl/v9.9.9/SHA256SUMS.minisig"
+_assert_file_contains "$MIR_SBX/curl.calls" "https://mirror.example.com/dl/v9.9.9/proxyhub_9.9.9_linux_amd64.tar.gz"
+_assert_file_not_contains "$MIR_SBX/curl.calls" "github.com"
+_assert_file_contains "$MIR_SBX/root/.proxyhub-install-info" "DOWNLOAD_BASE=https://mirror.example.com/dl"
+_assert_file_contains "$MIR_SBX/stderr.log" "signature verified"
+
+# Default base: probe stays on github.com, artifact URLs keep the current
+# GitHub releases shape, and the record carries the official base.
+defbase=$(
+    setup_sandbox
+    mock_host
+    export CURL_CALLS="$SBX/curl.calls"
+    rc=0
+    ( main --non-interactive --domain proxy.example.com --version 9.9.9 \
+        >"$SBX/stdout.log" 2>"$SBX/stderr.log" ) || rc=$?
+    printf 'RC=%d\nSBX=%s\n' "$rc" "$SBX"
+)
+defbase_rc=$(printf '%s\n' "$defbase" | sed -n 's/^RC=//p')
+DEF_SBX=$(printf '%s\n' "$defbase" | sed -n 's/^SBX=//p')
+TEST_DIRS+=("$DEF_SBX")
+
+_assert_eq 0 "$defbase_rc" "default download base install exit code"
+_assert_file_contains "$DEF_SBX/curl.calls" "https://github.com"
+_assert_file_contains "$DEF_SBX/curl.calls" "https://github.com/taliove/proxyhub/releases/download/v9.9.9/SHA256SUMS"
+_assert_file_contains "$DEF_SBX/curl.calls" "https://github.com/taliove/proxyhub/releases/download/v9.9.9/SHA256SUMS.minisig"
+_assert_file_contains "$DEF_SBX/curl.calls" "https://github.com/taliove/proxyhub/releases/download/v9.9.9/proxyhub_9.9.9_linux_amd64.tar.gz"
+_assert_file_contains "$DEF_SBX/root/.proxyhub-install-info" \
+    "DOWNLOAD_BASE=https://github.com/taliove/proxyhub/releases/download"
+_assert_file_contains "$DEF_SBX/stderr.log" "signature verified"
+
+# --------------------------------------------------------------------------
+# Signature verification fail-closed (ADR 0036)
+# --------------------------------------------------------------------------
+
+# Missing .minisig (a mirror that does not forward it): fail closed before
+# any binary lands.
+nomin=$(
+    setup_sandbox
+    mock_host
+    rm -f "$FIX_DIR/SHA256SUMS.minisig"
+    rc=0
+    ( main --non-interactive --domain proxy.example.com --version 9.9.9 \
+        >"$SBX/stdout.log" 2>"$SBX/stderr.log" ) || rc=$?
+    printf 'RC=%d\nSBX=%s\n' "$rc" "$SBX"
+)
+nomin_rc=$(printf '%s\n' "$nomin" | sed -n 's/^RC=//p')
+NOM_SBX=$(printf '%s\n' "$nomin" | sed -n 's/^SBX=//p')
+TEST_DIRS+=("$NOM_SBX")
+
+_assert_eq 1 "$nomin_rc" "missing .minisig exit code"
+_assert_file_contains "$NOM_SBX/stderr.log" "signature file missing"
+[[ ! -e $NOM_SBX/usr/local/bin/proxyhub ]] && _pass || _fail "binary installed despite missing .minisig"
+[[ ! -e $NOM_SBX/root/.proxyhub-install-info ]] && _pass || _fail "install record written despite missing .minisig"
+
+# Signature from the wrong key (mirror replaced SHA256SUMS AND its .minisig):
+# verification fails closed before any binary lands.
+badsig=$(
+    setup_sandbox
+    mock_host
+    openssl genpkey -algorithm ed25519 -out "$FIX_DIR/evilkey.pem" 2>/dev/null
+    sign_fixture_sums "$FIX_DIR/evilkey.pem" "$FIX_DIR/SHA256SUMS"
+    rc=0
+    ( main --non-interactive --domain proxy.example.com --version 9.9.9 \
+        >"$SBX/stdout.log" 2>"$SBX/stderr.log" ) || rc=$?
+    printf 'RC=%d\nSBX=%s\n' "$rc" "$SBX"
+)
+badsig_rc=$(printf '%s\n' "$badsig" | sed -n 's/^RC=//p')
+SIG_SBX=$(printf '%s\n' "$badsig" | sed -n 's/^SBX=//p')
+TEST_DIRS+=("$SIG_SBX")
+
+_assert_eq 1 "$badsig_rc" "wrong-key signature exit code"
+_assert_file_contains "$SIG_SBX/stderr.log" "signature verification FAILED"
+[[ ! -e $SIG_SBX/usr/local/bin/proxyhub ]] && _pass || _fail "binary installed despite a bad signature"
+[[ ! -e $SIG_SBX/root/.proxyhub-install-info ]] && _pass || _fail "install record written despite a bad signature"
+
+# --------------------------------------------------------------------------
+# Companion-source candidates (ADR 0036)
+# --------------------------------------------------------------------------
+
+# fetch_first_ok: a failing first candidate falls through to the next, in
+# order.
+cand=$(
+    SBX=$(mktemp -d "${TMPDIR:-/tmp}/proxyhub-cand.XXXXXX")
+    log="$SBX/curl.log"
+    : >"$log"
+    curl() {
+        local out="" url=""
+        while (($#)); do
+            case $1 in -o) out=$2; shift 2 ;; -*) shift ;; *) url=$1; shift ;; esac
+        done
+        printf '%s\n' "$url" >>"$log"
+        case $url in
+            *raw.githubusercontent.com*) printf 'fake ctl\n' >"$out" ;;
+            *) return 1 ;;
+        esac
+    }
+    rc=0
+    fetch_first_ok "$SBX/ctl" "" \
+        "https://cdn.jsdelivr.net/gh/taliove/proxyhub@main/scripts/install/proxyhubctl" \
+        "https://raw.githubusercontent.com/taliove/proxyhub/main/scripts/install/proxyhubctl" \
+        2>"$SBX/err.log" || rc=$?
+    printf 'RC=%d\nSBX=%s\n' "$rc" "$SBX"
+)
+cand_rc=$(printf '%s\n' "$cand" | sed -n 's/^RC=//p')
+CAND_SBX=$(printf '%s\n' "$cand" | sed -n 's/^SBX=//p')
+TEST_DIRS+=("$CAND_SBX")
+
+_assert_eq 0 "$cand_rc" "candidate fallback exit code"
+_assert_eq "fake ctl" "$(cat "$CAND_SBX/ctl")" "second candidate served the file"
+_assert_eq "https://cdn.jsdelivr.net/gh/taliove/proxyhub@main/scripts/install/proxyhubctl" \
+    "$(sed -n 1p "$CAND_SBX/curl.log")" "jsDelivr candidate tried first"
+_assert_eq "https://raw.githubusercontent.com/taliove/proxyhub/main/scripts/install/proxyhubctl" \
+    "$(sed -n 2p "$CAND_SBX/curl.log")" "raw.githubusercontent candidate tried second"
+_assert_file_contains "$CAND_SBX/err.log" "trying next source"
+
+# The explicit override wins over every candidate; candidates are never tried
+# (no silent fallback when the override fails either).
+ovr=$(
+    SBX=$(mktemp -d "${TMPDIR:-/tmp}/proxyhub-ovr.XXXXXX")
+    log="$SBX/curl.log"
+    : >"$log"
+    curl() {
+        local out="" url=""
+        while (($#)); do
+            case $1 in -o) out=$2; shift 2 ;; -*) shift ;; *) url=$1; shift ;; esac
+        done
+        printf '%s\n' "$url" >>"$log"
+        case $url in
+            *override.example.com*) printf 'override lib\n' >"$out" ;;
+            *) return 1 ;;
+        esac
+    }
+    rc=0
+    fetch_first_ok "$SBX/lib" "https://override.example.com/lib.sh" \
+        "https://cdn.jsdelivr.net/gh/taliove/proxyhub@main/scripts/install/lib.sh" \
+        "https://raw.githubusercontent.com/taliove/proxyhub/main/scripts/install/lib.sh" \
+        2>/dev/null || rc=$?
+    printf 'RC=%d\nSBX=%s\n' "$rc" "$SBX"
+)
+ovr_rc=$(printf '%s\n' "$ovr" | sed -n 's/^RC=//p')
+OVR_SBX=$(printf '%s\n' "$ovr" | sed -n 's/^SBX=//p')
+TEST_DIRS+=("$OVR_SBX")
+
+_assert_eq 0 "$ovr_rc" "override priority exit code"
+_assert_eq "https://override.example.com/lib.sh" "$(cat "$OVR_SBX/curl.log")" \
+    "override wins; built-in candidates never tried"
+
+# Every candidate failing is a hard error.
+allfail=$(
+    SBX=$(mktemp -d "${TMPDIR:-/tmp}/proxyhub-allfail.XXXXXX")
+    curl() { return 1; }
+    rc=0
+    fetch_first_ok "$SBX/lib" "" \
+        "https://a.example.com/lib.sh" "https://b.example.com/lib.sh" \
+        2>"$SBX/err.log" || rc=$?
+    printf 'RC=%d\nSBX=%s\n' "$rc" "$SBX"
+)
+allfail_rc=$(printf '%s\n' "$allfail" | sed -n 's/^RC=//p')
+AF_SBX=$(printf '%s\n' "$allfail" | sed -n 's/^SBX=//p')
+TEST_DIRS+=("$AF_SBX")
+
+_assert_eq 1 "$allfail_rc" "all candidates failing exit code"
+_assert_file_contains "$AF_SBX/err.log" "all download candidates failed"
+[[ ! -e $AF_SBX/lib ]] && _pass || _fail "file written despite all candidates failing"
+
+# Header companion-lib candidates: piped install.sh (curl | bash form) with a
+# failing jsDelivr falls back to raw.githubusercontent, in order.
+_hdr_tmp=$(mktemp -d "${TMPDIR:-/tmp}/proxyhub-hdr.XXXXXX")
+TEST_DIRS+=("$_hdr_tmp")
+mkdir -p "$_hdr_tmp/root"
+cat >"$_hdr_tmp/curl" <<'EOF'
+#!/usr/bin/env bash
+out="" url=""
+while (($#)); do
+    case $1 in -o) out=$2; shift 2 ;; -*) shift ;; *) url=$1; shift ;; esac
+done
+printf '%s\n' "$url" >>"${FAKECURL_LOG}"
+case $url in
+    *raw.githubusercontent.com*/scripts/install/lib.sh) cp "${FAKECURL_LIB}" "$out" ;;
+    *) exit 22 ;;
+esac
+EOF
+chmod +x "$_hdr_tmp/curl"
+hdr_out=$(cd "${TMPDIR:-/tmp}" && env -u PROXYHUB_INSTALL_NO_MAIN \
+    PATH="$_hdr_tmp:/usr/bin:/bin" \
+    FAKECURL_LOG="$_hdr_tmp/curl.log" \
+    FAKECURL_LIB="$REPO_ROOT/scripts/install/lib.sh" \
+    PROXYHUB_ROOT="$_hdr_tmp/root" \
+    bash -s -- --help <"$REPO_ROOT/install.sh" 2>&1) && _pass ||
+    _fail "piped install.sh with candidate fallback failed: $hdr_out"
+[[ $hdr_out == *"--download-base"* ]] && _pass || _fail "piped fallback help content wrong"
+_assert_eq "https://cdn.jsdelivr.net/gh/taliove/proxyhub@main/scripts/install/lib.sh" \
+    "$(sed -n 1p "$_hdr_tmp/curl.log")" "header tries jsDelivr first"
+_assert_eq "https://raw.githubusercontent.com/taliove/proxyhub/main/scripts/install/lib.sh" \
+    "$(sed -n 2p "$_hdr_tmp/curl.log")" "header falls back to raw.githubusercontent"
 
 # --------------------------------------------------------------------------
 

--- a/scripts/install/test_install.sh
+++ b/scripts/install/test_install.sh
@@ -963,6 +963,39 @@ _assert_file_contains "$DEF_SBX/root/.proxyhub-install-info" \
     "DOWNLOAD_BASE=https://github.com/taliove/proxyhub/releases/download"
 _assert_file_contains "$DEF_SBX/stderr.log" "signature verified"
 
+# Probe tolerance: a bare mirror base answering 404 (real curl -f would exit
+# 22) must NOT fail the connectivity check - the probe proves transport
+# reachability only (Spec review: ghproxy-style bases 404 on the bare path).
+probe404=$(
+    setup_sandbox
+    mock_host
+    eval "_mock_curl_orig() $(declare -f _curl | tail -n +2)"
+    _curl() {
+        local has_f=0 arg url=""
+        for arg in "$@"; do
+            case $arg in
+                -*f*) has_f=1 ;;
+                http*) url=$arg ;;
+            esac
+        done
+        if [[ $url == "https://mirror.example.com/dl" && $has_f == 1 ]]; then
+            return 22 # real curl -f behavior on a 404 bare mirror base
+        fi
+        _mock_curl_orig "$@"
+    }
+    export CURL_CALLS="$SBX/curl.calls"
+    rc=0
+    ( main --non-interactive --domain proxy.example.com --version 9.9.9 \
+        --download-base "https://mirror.example.com/dl" \
+        >"$SBX/stdout.log" 2>"$SBX/stderr.log" ) || rc=$?
+    printf 'RC=%d\nSBX=%s\n' "$rc" "$SBX"
+)
+probe404_rc=$(printf '%s\n' "$probe404" | sed -n 's/^RC=//p')
+P404_SBX=$(printf '%s\n' "$probe404" | sed -n 's/^SBX=//p')
+TEST_DIRS+=("$P404_SBX")
+_assert_eq 0 "$probe404_rc" "404 mirror base tolerated by connectivity probe"
+_assert_file_contains "$P404_SBX/root/.proxyhub-install-info" "DOWNLOAD_BASE=https://mirror.example.com/dl"
+
 # --------------------------------------------------------------------------
 # Signature verification fail-closed (ADR 0036)
 # --------------------------------------------------------------------------

--- a/scripts/install/test_install.sh
+++ b/scripts/install/test_install.sh
@@ -1113,6 +1113,25 @@ _assert_eq 0 "$ovr_rc" "override priority exit code"
 _assert_eq "https://override.example.com/lib.sh" "$(cat "$OVR_SBX/curl.log")" \
     "override wins; built-in candidates never tried"
 
+# Plaintext override URLs are refused outside test mode (the override names
+# code executed as root; the guard fires before any network call).
+plain=$(
+    SBX=$(mktemp -d "${TMPDIR:-/tmp}/proxyhub-plain.XXXXXX")
+    export PROXYHUB_ROOT=""
+    curl() { printf 'SHOULD-NOT-FETCH\n'; }
+    rc=0
+    fetch_first_ok "$SBX/lib" "http://override.example.com/lib.sh" \
+        "https://cdn.jsdelivr.net/gh/taliove/proxyhub@main/scripts/install/lib.sh" \
+        2>"$SBX/err.log" || rc=$?
+    printf 'RC=%d\nSBX=%s\n' "$rc" "$SBX"
+)
+plain_rc=$(printf '%s\n' "$plain" | sed -n 's/^RC=//p')
+PLAIN_SBX=$(printf '%s\n' "$plain" | sed -n 's/^SBX=//p')
+TEST_DIRS+=("$PLAIN_SBX")
+_assert_eq 1 "$plain_rc" "plaintext override refused exit code"
+_assert_file_contains "$PLAIN_SBX/err.log" "must use https://"
+[[ ! -e $PLAIN_SBX/lib ]] && _pass || _fail "file written despite plaintext refusal"
+
 # Every candidate failing is a hard error.
 allfail=$(
     SBX=$(mktemp -d "${TMPDIR:-/tmp}/proxyhub-allfail.XXXXXX")

--- a/scripts/install/test_lib.sh
+++ b/scripts/install/test_lib.sh
@@ -190,7 +190,8 @@ _assert_eq "/tmp/x/etc/proxyhub" "$(PROXYHUB_ROOT=/tmp/x root_path /etc/proxyhub
 # --------------------------------------------------------------------------
 
 TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/proxyhub-lib-test.XXXXXX")
-trap 'rm -rf "$TEST_ROOT"' EXIT
+SIGN_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/proxyhub-sign-test.XXXXXX")
+trap 'rm -rf "$TEST_ROOT" "$SIGN_ROOT"' EXIT
 
 _assert_ok env PROXYHUB_ROOT="$TEST_ROOT" bash -c 'source "$0"; ensure_proxyhub_group' "$SCRIPT_DIR/lib.sh"
 _assert_ok env PROXYHUB_ROOT="$TEST_ROOT" bash -c 'source "$0"; ensure_proxyhub_user' "$SCRIPT_DIR/lib.sh"
@@ -667,6 +668,73 @@ _assert_ok env PROXYHUB_ROOT="$TEST_ROOT" PROXYHUB_CADDY_MODE=docker PROXYHUB_DO
 _assert_file_contains "$TEST_ROOT/srv/caddy-br/conf.d/proxyhub.caddy" "reverse_proxy host.docker.internal:8080"
 _assert_file_contains "$TEST_ROOT/srv/caddy-br/conf.d/proxyhub.caddy" "header_up X-Forwarded-For {remote_host}"
 _assert_file_contains "$TEST_ROOT/srv/caddy-br/conf.d/proxyhub.caddy" "header_up X-Real-IP {remote_host}"
+
+# --------------------------------------------------------------------------
+# verify_minisig (ADR 0036 signature trust anchor)
+# --------------------------------------------------------------------------
+
+# The verifier may only rely on tools a stock Ubuntu/Debian base image always
+# ships: coreutils (base64/tail/head/wc/sed/mktemp) + openssl.
+for tool in base64 tail head wc sed mktemp openssl; do
+    _assert_ok command -v "$tool"
+done
+
+# Synthetic throwaway Ed25519 keypair, generated inside the test scratch and
+# destroyed with it. Never committed, never usable for real releases.
+openssl genpkey -algorithm ed25519 -out "$SIGN_ROOT/testkey.pem" 2>/dev/null
+openssl pkey -in "$SIGN_ROOT/testkey.pem" -pubout -outform DER 2>/dev/null \
+    | tail -c 32 >"$SIGN_ROOT/testkey.raw"
+# Minisign text-format pubkey: base64("Ed" || 8-byte keynum || 32-byte key).
+TEST_PUBKEY_B64=$( { printf 'Ed'; head -c 8 /dev/zero; cat "$SIGN_ROOT/testkey.raw"; } | base64 | tr -d '\n')
+
+# _make_minisig PRIVKEY_PEM FILE OUT - assemble a minisign-format .minisig for
+# FILE using a test private key: line 1 is a comment, line 2 is
+# base64("Ed" || 8-byte keynum || 64-byte Ed25519 signature).
+_make_minisig() {
+    openssl pkeyutl -sign -inkey "$1" -rawin -in "$2" -out "$3.sigbin" 2>/dev/null
+    {
+        printf 'untrusted comment: signature from synthetic test key\n'
+        { printf 'Ed'; head -c 8 /dev/zero; cat "$3.sigbin"; } | base64 | tr -d '\n'
+        printf '\n'
+    } >"$3"
+}
+
+printf '%s  %s\n' "0000000000000000000000000000000000000000000000000000000000000000" \
+    "proxyhub_0.0.0_linux_amd64.tar.gz" >"$SIGN_ROOT/SHA256SUMS"
+_make_minisig "$SIGN_ROOT/testkey.pem" "$SIGN_ROOT/SHA256SUMS" "$SIGN_ROOT/SHA256SUMS.minisig"
+
+# Positive: a valid signature verifies.
+_assert_ok verify_minisig "$SIGN_ROOT/SHA256SUMS" "$SIGN_ROOT/SHA256SUMS.minisig" "$TEST_PUBKEY_B64"
+
+# Tamper: content changed after signing is rejected.
+printf '%s  %s\n' "1111111111111111111111111111111111111111111111111111111111111111" \
+    "proxyhub_0.0.0_linux_amd64.tar.gz" >"$SIGN_ROOT/SHA256SUMS.tampered"
+_assert_fail verify_minisig "$SIGN_ROOT/SHA256SUMS.tampered" "$SIGN_ROOT/SHA256SUMS.minisig" "$TEST_PUBKEY_B64"
+
+# Missing .minisig fails closed.
+_assert_fail verify_minisig "$SIGN_ROOT/SHA256SUMS" "$SIGN_ROOT/SHA256SUMS.minisig.absent" "$TEST_PUBKEY_B64"
+
+# Malformed .minisig fails closed: wrong decoded length, wrong prefix.
+printf 'untrusted comment: x\n%s\n' "$(printf 'EdSHORT' | base64 | tr -d '\n')" >"$SIGN_ROOT/badsize.minisig"
+_assert_fail verify_minisig "$SIGN_ROOT/SHA256SUMS" "$SIGN_ROOT/badsize.minisig" "$TEST_PUBKEY_B64"
+{
+    printf 'untrusted comment: x\n'
+    { printf 'ED'; head -c 72 /dev/zero; } | base64 | tr -d '\n'
+    printf '\n'
+} >"$SIGN_ROOT/badprefix.minisig"
+_assert_fail verify_minisig "$SIGN_ROOT/SHA256SUMS" "$SIGN_ROOT/badprefix.minisig" "$TEST_PUBKEY_B64"
+
+# Embedded release pubkey constant is well-formed minisign text format.
+_assert_eq "42" "$(printf '%s' "$PROXYHUB_MINISIGN_PUBKEY" | base64 -d | wc -c | tr -d ' ')" \
+    "embedded pubkey decodes to 42 bytes"
+_assert_eq "Ed" "$(printf '%s' "$PROXYHUB_MINISIGN_PUBKEY" | base64 -d | head -c 2)" \
+    "embedded pubkey has Ed prefix"
+
+# Missing openssl fails closed (stripped PATH; the openssl check fires before
+# any other tool is needed).
+_assert_fail env PATH=/nonexistent bash -c \
+    'source "$0"; verify_minisig "$1" "$2" "$3"' \
+    "$SCRIPT_DIR/lib.sh" "$SIGN_ROOT/SHA256SUMS" "$SIGN_ROOT/SHA256SUMS.minisig" "$TEST_PUBKEY_B64"
 
 # --------------------------------------------------------------------------
 

--- a/scripts/install/test_proxyhubctl.sh
+++ b/scripts/install/test_proxyhubctl.sh
@@ -174,6 +174,28 @@ test_show_info() {
     assert_contains "$output" "VERSION=v1.2.3"
 }
 
+test_status_shows_default_download_base() {
+    # The shared record predates the DOWNLOAD_BASE field: status reports the
+    # official GitHub releases base as the effective download base (ADR 0036).
+    local output
+    output=$(bash "$PROXYHUB_ROOT/usr/local/bin/proxyhubctl" status 2>&1)
+    assert_contains "$output" "Download base:"
+    assert_contains "$output" "https://github.com/taliove/proxyhub/releases/download"
+}
+
+test_status_shows_record_download_base() {
+    # A record written by install.sh --download-base: status reports the
+    # recorded mirror as the effective download base.
+    local record="$PROXYHUB_ROOT/root/.proxyhub-install-info"
+    cp "$record" "${record}.orig"
+    printf 'DOWNLOAD_BASE=https://mirror.example.com/dl\n' >>"$record"
+    local output
+    output=$(bash "$PROXYHUB_ROOT/usr/local/bin/proxyhubctl" status 2>&1)
+    mv "${record}.orig" "$record"
+    assert_contains "$output" "Download base:"
+    assert_contains "$output" "https://mirror.example.com/dl"
+}
+
 test_help() {
     local output
     output=$(bash "$PROXYHUB_ROOT/usr/local/bin/proxyhubctl" --help 2>&1)
@@ -388,6 +410,8 @@ main() {
     test_logs_with_lines
     test_restart
     test_show_info
+    test_status_shows_default_download_base
+    test_status_shows_record_download_base
     test_help
     test_reset_mfa_with_yes
     test_reset_mfa_interactive_confirm

--- a/scripts/install/test_update.sh
+++ b/scripts/install/test_update.sh
@@ -17,6 +17,19 @@ TESTS_FAILED=0
 # Test framework helpers
 # --------------------------------------------------------------------------
 
+# sign_fixture_sums PRIVKEY_PEM SUMS_FILE - (re)sign a fixture SHA256SUMS in
+# minisign text format: line 2 = base64("Ed" || 8-byte keynum || signature).
+# Same assembly as test_install.sh's helper.
+sign_fixture_sums() {
+    openssl pkeyutl -sign -inkey "$1" -rawin -in "$2" -out "$2.sigbin" 2>/dev/null
+    {
+        printf 'untrusted comment: signature from synthetic test key\n'
+        { printf 'Ed'; head -c 8 /dev/zero; cat "$2.sigbin"; } | base64 | tr -d '\n'
+        printf '\n'
+    } >"$2.minisig"
+    rm -f "$2.sigbin"
+}
+
 # setup_test - create a test environment.
 setup_test() {
     export PROXYHUB_ROOT
@@ -70,41 +83,35 @@ EOFBIN
     export PATH="${PROXYHUB_ROOT}/bin:${PATH}"
     mkdir -p "${PROXYHUB_ROOT}/bin"
     
-    # Mock curl.
+    # Mock curl: logs every invocation to curl.calls, serves the
+    # api.github.com latest-release JSON, the signed fixture SHA256SUMS and
+    # its .minisig, and a freshly built mock tarball for any .tar.gz URL.
     cat > "${PROXYHUB_ROOT}/bin/curl" <<'EOFCURL'
 #!/usr/bin/env bash
 # Mock curl for testing.
+printf '%s\n' "$*" >> "${PROXYHUB_ROOT}/curl.calls"
 prev_arg=""
+out=""
+for arg in "$@"; do
+    if [[ "$prev_arg" == "-o" ]]; then out="$arg"; fi
+    prev_arg="$arg"
+done
 if [[ "$*" == *"api.github.com/repos"*"/releases/latest"* ]]; then
     echo '{"tag_name":"v1.1.0","prerelease":false}'
     exit 0
 fi
-if [[ "$*" == *"SHA256SUMS"* ]]; then
-    # Find output file. Emit the full release-matrix manifest (5 targets),
-    # matching scripts/release/package.sh output shape, with a syntactically
-    # valid 64-hex fake checksum.
-    for arg in "$@"; do
-        if [[ "$prev_arg" == "-o" ]]; then
-            {
-                echo "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  proxyhub_1.1.0_darwin_amd64.tar.gz"
-                echo "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  proxyhub_1.1.0_darwin_arm64.tar.gz"
-                echo "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  proxyhub_1.1.0_linux_amd64.tar.gz"
-                echo "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  proxyhub_1.1.0_linux_arm64.tar.gz"
-                echo "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  proxyhub_1.1.0_windows_amd64.tar.gz"
-            } > "$arg"
-            exit 0
-        fi
-        prev_arg="$arg"
-    done
+if [[ "$*" == *"SHA256SUMS.minisig"* ]]; then
+    [[ -n "$out" ]] && cp "${PROXYHUB_ROOT}/fixtures/SHA256SUMS.minisig" "$out" && exit 0
     exit 1
 fi
-if [[ "$*" == *".tar.gz"* ]]; then
-    # Find output file.
-    for arg in "$@"; do
-        if [[ "$prev_arg" == "-o" ]]; then
-            # Create a minimal tarball with mock binary.
-            tmpdir=$(mktemp -d)
-            cat > "${tmpdir}/proxyhub" <<'EOFNEWBIN'
+if [[ "$*" == *"SHA256SUMS"* ]]; then
+    [[ -n "$out" ]] && cp "${PROXYHUB_ROOT}/fixtures/SHA256SUMS" "$out" && exit 0
+    exit 1
+fi
+if [[ "$*" == *".tar.gz"* && -n "$out" ]]; then
+    # Create a minimal tarball with mock binary.
+    tmpdir=$(mktemp -d)
+    cat > "${tmpdir}/proxyhub" <<'EOFNEWBIN'
 #!/usr/bin/env bash
 if [[ "$1" == "state-fingerprint" ]]; then
     case " $* " in
@@ -120,14 +127,10 @@ if [[ "$1" == "state-fingerprint" ]]; then
 fi
 exit 1
 EOFNEWBIN
-            chmod +x "${tmpdir}/proxyhub"
-            tar -czf "$arg" -C "$tmpdir" proxyhub
-            rm -rf "$tmpdir"
-            exit 0
-        fi
-        prev_arg="$arg"
-    done
-    exit 1
+    chmod +x "${tmpdir}/proxyhub"
+    tar -czf "$out" -C "$tmpdir" proxyhub
+    rm -rf "$tmpdir"
+    exit 0
 fi
 exit 1
 EOFCURL
@@ -143,6 +146,31 @@ fi
 /usr/bin/sha256sum "$@"
 EOFSHA
     chmod +x "${PROXYHUB_ROOT}/bin/sha256sum"
+
+    # Signature trust chain fixture (ADR 0036): a throwaway Ed25519 keypair
+    # per test. The mock curl serves a SHA256SUMS manifest signed with it and
+    # the ctl subprocess verifies against the exported public key (lib.sh
+    # reads PROXYHUB_MINISIGN_PUBKEY from the environment; the production
+    # constant stays untouched). The manifest lists the full release matrix
+    # with a syntactically valid 64-hex fake checksum, matching
+    # scripts/release/package.sh output shape.
+    local fix_dir="${PROXYHUB_ROOT}/fixtures"
+    mkdir -p "$fix_dir"
+    cat > "${fix_dir}/SHA256SUMS" <<'EOFSUMS'
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  proxyhub_1.1.0_darwin_amd64.tar.gz
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  proxyhub_1.1.0_darwin_arm64.tar.gz
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  proxyhub_1.1.0_linux_amd64.tar.gz
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  proxyhub_1.1.0_linux_arm64.tar.gz
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  proxyhub_1.1.0_windows_amd64.tar.gz
+EOFSUMS
+    openssl genpkey -algorithm ed25519 -out "${fix_dir}/testkey.pem" 2>/dev/null
+    openssl pkey -in "${fix_dir}/testkey.pem" -pubout -outform DER 2>/dev/null \
+        | tail -c 32 >"${fix_dir}/testkey.raw"
+    PROXYHUB_MINISIGN_PUBKEY=$(
+        { printf 'Ed'; head -c 8 /dev/zero; cat "${fix_dir}/testkey.raw"; } | base64 | tr -d '\n'
+    )
+    export PROXYHUB_MINISIGN_PUBKEY
+    sign_fixture_sums "${fix_dir}/testkey.pem" "${fix_dir}/SHA256SUMS"
 }
 
 teardown_test() {
@@ -150,6 +178,7 @@ teardown_test() {
         rm -rf "$PROXYHUB_ROOT"
         unset PROXYHUB_ROOT
     fi
+    unset PROXYHUB_MINISIGN_PUBKEY
 }
 
 assert_true() {
@@ -274,6 +303,153 @@ EOFSHA
 }
 
 # --------------------------------------------------------------------------
+# Download base and signature gate (ADR 0036, ticket C4/#27)
+# --------------------------------------------------------------------------
+
+# mark_live_binary - append a sentinel comment to the installed mock binary so
+# fail-closed tests can prove the in-service binary was never replaced.
+mark_live_binary() {
+    LIVE_BINARY=$(root_path /usr/local/bin/proxyhub)
+    LIVE_SENTINEL="# sentinel-$$"
+    printf '%s\n' "$LIVE_SENTINEL" >>"$LIVE_BINARY"
+}
+
+# assert_install_untouched MSG_PREFIX - after a refused update: the sentinel
+# survives in the live binary and the record still reads v1.0.0.
+assert_install_untouched() {
+    assert_true "grep -qF '$LIVE_SENTINEL' '$LIVE_BINARY'" \
+        "$1: in-service binary not replaced"
+    local version
+    version=$(grep '^VERSION=' "$(root_path /root/.proxyhub-install-info)" | cut -d= -f2)
+    assert_true "[[ '$version' == 'v1.0.0' ]]" "$1: version unchanged"
+}
+
+test_update_mirror_record_base() {
+    echo "==> test_update_mirror_record_base"
+    setup_test
+
+    # Record carries a mirror download base (written by install.sh
+    # --download-base at install time); update must follow it.
+    printf 'DOWNLOAD_BASE=https://mirror.example.com/dl\n' \
+        >>"$(root_path /root/.proxyhub-install-info)"
+
+    "$PROXYHUBCTL" update v1.1.0
+
+    local new_version
+    new_version=$(grep '^VERSION=' "$(root_path /root/.proxyhub-install-info)" | cut -d= -f2)
+    assert_true "[[ '$new_version' == 'v1.1.0' ]]" "mirror-mode update bumps the version"
+    assert_true "grep -qF 'https://mirror.example.com/dl/v1.1.0/SHA256SUMS.minisig' '$PROXYHUB_ROOT/curl.calls'" \
+        "signature file fetched from the recorded mirror"
+    assert_true "grep -qF 'https://mirror.example.com/dl/v1.1.0/proxyhub_1.1.0_linux_amd64.tar.gz' '$PROXYHUB_ROOT/curl.calls'" \
+        "tarball fetched from the recorded mirror"
+    assert_true "! grep -q 'github.com' '$PROXYHUB_ROOT/curl.calls'" \
+        "mirror mode never contacts github.com"
+
+    teardown_test
+}
+
+test_update_explicit_download_base_wins() {
+    echo "==> test_update_explicit_download_base_wins"
+    setup_test
+
+    printf 'DOWNLOAD_BASE=https://record-mirror.example.com/dl\n' \
+        >>"$(root_path /root/.proxyhub-install-info)"
+
+    "$PROXYHUBCTL" update v1.1.0 --download-base https://flag-mirror.example.com/dl
+
+    local new_version
+    new_version=$(grep '^VERSION=' "$(root_path /root/.proxyhub-install-info)" | cut -d= -f2)
+    assert_true "[[ '$new_version' == 'v1.1.0' ]]" "explicit-flag update bumps the version"
+    assert_true "grep -qF 'https://flag-mirror.example.com/dl/v1.1.0/proxyhub_1.1.0_linux_amd64.tar.gz' '$PROXYHUB_ROOT/curl.calls'" \
+        "explicit --download-base wins over the record"
+    assert_true "! grep -q 'record-mirror' '$PROXYHUB_ROOT/curl.calls'" \
+        "recorded mirror not contacted when the flag is given"
+
+    teardown_test
+}
+
+test_update_old_record_defaults_github() {
+    echo "==> test_update_old_record_defaults_github"
+    setup_test
+
+    # The setup_test record predates the DOWNLOAD_BASE field: the effective
+    # base must fall back to the official GitHub releases base.
+    "$PROXYHUBCTL" update v1.1.0
+
+    assert_true "grep -qF 'https://github.com/taliove/proxyhub/releases/download/v1.1.0/SHA256SUMS.minisig' '$PROXYHUB_ROOT/curl.calls'" \
+        "old record: signature file fetched from the official base"
+    assert_true "grep -qF 'https://github.com/taliove/proxyhub/releases/download/v1.1.0/proxyhub_1.1.0_linux_amd64.tar.gz' '$PROXYHUB_ROOT/curl.calls'" \
+        "old record: tarball fetched from the official base"
+
+    teardown_test
+}
+
+test_update_mirror_requires_explicit_version() {
+    echo "==> test_update_mirror_requires_explicit_version"
+    setup_test
+
+    printf 'DOWNLOAD_BASE=https://mirror.example.com/dl\n' \
+        >>"$(root_path /root/.proxyhub-install-info)"
+
+    local rc=0 output
+    output=$("$PROXYHUBCTL" update 2>&1) || rc=$?
+
+    assert_true "[[ $rc -eq 2 ]]" "mirror + no explicit version exits 2"
+    printf '%s' "$output" >"$PROXYHUB_ROOT/out.log"
+    assert_true "grep -qF 'custom download base requires an explicit --version (latest resolution needs GitHub)' '$PROXYHUB_ROOT/out.log'" \
+        "guidance matches install.sh wording"
+    assert_true "[[ ! -e '$PROXYHUB_ROOT/curl.calls' ]]" "no network call before the refusal"
+    local version
+    version=$(grep '^VERSION=' "$(root_path /root/.proxyhub-install-info)" | cut -d= -f2)
+    assert_true "[[ '$version' == 'v1.0.0' ]]" "version unchanged after refusal"
+
+    teardown_test
+}
+
+test_update_missing_minisig_fails_closed() {
+    echo "==> test_update_missing_minisig_fails_closed"
+    setup_test
+
+    # A mirror that does not forward the .minisig: the download fails and the
+    # update must refuse before the live binary is touched.
+    rm -f "$PROXYHUB_ROOT/fixtures/SHA256SUMS.minisig"
+    mark_live_binary
+
+    local rc=0 output
+    output=$("$PROXYHUBCTL" update v1.1.0 2>&1) || rc=$?
+
+    assert_true "[[ $rc -eq 1 ]]" "missing .minisig exits 1"
+    printf '%s' "$output" >"$PROXYHUB_ROOT/out.log"
+    assert_true "grep -qF 'SHA256SUMS.minisig' '$PROXYHUB_ROOT/out.log'" \
+        "error names the missing signature file"
+    assert_install_untouched "missing .minisig"
+
+    teardown_test
+}
+
+test_update_bad_signature_fails_closed() {
+    echo "==> test_update_bad_signature_fails_closed"
+    setup_test
+
+    # The mirror replaced SHA256SUMS AND its .minisig (signed with a
+    # different key): verification must fail closed.
+    openssl genpkey -algorithm ed25519 -out "$PROXYHUB_ROOT/fixtures/evilkey.pem" 2>/dev/null
+    sign_fixture_sums "$PROXYHUB_ROOT/fixtures/evilkey.pem" "$PROXYHUB_ROOT/fixtures/SHA256SUMS"
+    mark_live_binary
+
+    local rc=0 output
+    output=$("$PROXYHUBCTL" update v1.1.0 2>&1) || rc=$?
+
+    assert_true "[[ $rc -eq 1 ]]" "wrong-key signature exits 1"
+    printf '%s' "$output" >"$PROXYHUB_ROOT/out.log"
+    assert_true "grep -qF 'signature verification FAILED' '$PROXYHUB_ROOT/out.log'" \
+        "signature failure is reported"
+    assert_install_untouched "bad signature"
+
+    teardown_test
+}
+
+# --------------------------------------------------------------------------
 # Docker caddy mode (ADR 0035, ticket 04/#19)
 # --------------------------------------------------------------------------
 
@@ -385,6 +561,12 @@ main() {
     test_update_happy_path
     test_update_prerelease_gating
     test_update_checksum_fail_rollback
+    test_update_mirror_record_base
+    test_update_explicit_download_base_wins
+    test_update_old_record_defaults_github
+    test_update_mirror_requires_explicit_version
+    test_update_missing_minisig_fails_closed
+    test_update_bad_signature_fails_closed
     test_update_docker_happy
     test_update_docker_lost_container
 

--- a/scripts/release/package.sh
+++ b/scripts/release/package.sh
@@ -18,6 +18,10 @@
 #                          (git log -1 --format=%ct). Same tree + same epoch
 #                          => byte-identical tarballs.
 #   OUTPUT_DIR=path        Output directory (default: dist/release).
+#   MINISIGN_KEY_FILE=path minisign private key file. When set, SHA256SUMS is
+#                          signed into SHA256SUMS.minisig (the CI release path,
+#                          ADR 0036). When unset, signing is skipped with a
+#                          WARN so local rehearsals stay unblocked.
 #
 set -Eeuo pipefail
 
@@ -108,6 +112,27 @@ sha256() { # file
   fi
 }
 
+# sign_sums PUBLISH_DIR - sign PUBLISH_DIR/SHA256SUMS into SHA256SUMS.minisig
+# with minisign when MINISIGN_KEY_FILE points at a private key file. The
+# release workflow always sets it (and fails earlier when the secret is
+# absent), so a missing key here only happens in local rehearsals: warn and
+# leave the manifest unsigned. Key material is never logged.
+sign_sums() {
+  local dir="$1"
+  if [[ -z "${MINISIGN_KEY_FILE:-}" ]]; then
+    log "WARN: MINISIGN_KEY_FILE not set - leaving SHA256SUMS unsigned (local rehearsal only; releases must be signed)"
+    return 0
+  fi
+  [[ -f "$MINISIGN_KEY_FILE" ]] || { log "MINISIGN_KEY_FILE '$MINISIGN_KEY_FILE' does not exist"; return 1; }
+  command -v minisign >/dev/null 2>&1 || { log "minisign is required to sign SHA256SUMS"; return 1; }
+  # Legacy (non-prehashed) format is mandatory: minisign >= 0.11 prehashes by
+  # default, and the openssl verifier in scripts/install/lib.sh only accepts
+  # the legacy "Ed" signature layout.
+  minisign -S -l -s "$MINISIGN_KEY_FILE" -x "$dir/SHA256SUMS.minisig" -m "$dir/SHA256SUMS" || return 1
+  [[ -f "$dir/SHA256SUMS.minisig" ]] || { log "minisign produced no SHA256SUMS.minisig"; return 1; }
+  log "signed SHA256SUMS -> SHA256SUMS.minisig"
+}
+
 # --- Main --------------------------------------------------------------------
 
 workspace=""
@@ -159,13 +184,16 @@ main() {
   done < <(printf '%s\n' "${assets[@]}" | LC_ALL=C sort)
   mv "$sums_tmp" "$publish/SHA256SUMS"
 
+  sign_sums "$publish" || fail "could not sign SHA256SUMS"
+
   mkdir -p "$OUTPUT_DIR"
-  rm -f "$OUTPUT_DIR"/proxyhub_*.tar.gz "$OUTPUT_DIR/SHA256SUMS"
+  rm -f "$OUTPUT_DIR"/proxyhub_*.tar.gz "$OUTPUT_DIR/SHA256SUMS" "$OUTPUT_DIR/SHA256SUMS.minisig"
   cp "$publish"/* "$OUTPUT_DIR/" || fail "could not publish to $OUTPUT_DIR"
 
   log "release assets written to $OUTPUT_DIR:"
   local f
-  for f in "$OUTPUT_DIR"/proxyhub_*.tar.gz "$OUTPUT_DIR/SHA256SUMS"; do
+  for f in "$OUTPUT_DIR"/proxyhub_*.tar.gz "$OUTPUT_DIR/SHA256SUMS" "$OUTPUT_DIR/SHA256SUMS.minisig"; do
+    [[ -f "$f" ]] || continue
     log "  $(basename "$f")"
   done
 }

--- a/scripts/release/verify.sh
+++ b/scripts/release/verify.sh
@@ -69,11 +69,8 @@ verify_dir_signature() {
   local dir="$1"
   local sums="$dir/SHA256SUMS" minisig="$dir/SHA256SUMS.minisig"
   if [[ -f "$minisig" ]] && compgen -G "$dir/proxyhub_*.tar.gz" >/dev/null; then
-    if [[ -n "${MINISIGN_PUBKEY_B64:-}" ]]; then
-      verify_minisig "$sums" "$minisig" "$MINISIGN_PUBKEY_B64" || return 1
-    else
-      verify_minisig "$sums" "$minisig" || return 1
-    fi
+    # Empty third arg falls back to the embedded key inside verify_minisig.
+    verify_minisig "$sums" "$minisig" "${MINISIGN_PUBKEY_B64:-}" || return 1
     log "OK SHA256SUMS.minisig (minisign signature over SHA256SUMS)"
     return 0
   fi

--- a/scripts/release/verify.sh
+++ b/scripts/release/verify.sh
@@ -1,10 +1,19 @@
 #!/usr/bin/env bash
 #
-# verify.sh — verify release tarballs against a SHA256SUMS manifest.
+# verify.sh — verify release tarballs against a SHA256SUMS manifest, plus the
+# minisign signature over that manifest (the trust anchor, ADR 0036).
 #
 # Usage:
 #   scripts/release/verify.sh dist/release                 # verify everything listed in dist/release/SHA256SUMS
 #   scripts/release/verify.sh dist/release/proxyhub_0.1.0_linux_amd64.tar.gz [more.tar.gz ...]
+#
+# Environment knobs:
+#   MINISIGN_PUBKEY_B64  base64 minisign public key overriding the embedded
+#                        release key (used by local rehearsals with a
+#                        throwaway key pair).
+#   MINISIGN_KEY_FILE    set by package.sh when signing was requested; if a
+#                        directory then lacks SHA256SUMS.minisig, that is an
+#                        error (a signed release must not silently degrade).
 #
 set -Eeuo pipefail
 
@@ -12,6 +21,13 @@ LOG_PREFIX="[proxyhub-release]"
 
 log()  { printf '%s %s\n' "$LOG_PREFIX" "$*"; }
 fail() { printf '%s ERROR: %s\n' "$LOG_PREFIX" "$*" >&2; exit 1; }
+
+# verify_minisig (openssl-based, no minisign dependency) lives in the shared
+# install library next to the embedded release public key.
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=../install/lib.sh
+# shellcheck disable=SC1090,SC1091
+source "$repo_root/scripts/install/lib.sh"
 
 sha256() { # file
   if command -v sha256sum >/dev/null 2>&1; then
@@ -42,6 +58,33 @@ verify_one() { # tarball sums_file
   log "OK $name"
 }
 
+# verify_dir_signature DIR - minisign trust-anchor check for DIR/SHA256SUMS.
+# Policy (ADR 0036): when a directory holds release tarballs AND
+# SHA256SUMS.minisig, the signature must verify against the embedded public
+# key (MINISIGN_PUBKEY_B64 overrides it for rehearsal keys). A directory with
+# tarballs but NO .minisig is an error only when signing was explicitly
+# requested (MINISIGN_KEY_FILE set) - a signed release must not silently
+# degrade; otherwise it is an unsigned local rehearsal and only warns.
+verify_dir_signature() {
+  local dir="$1"
+  local sums="$dir/SHA256SUMS" minisig="$dir/SHA256SUMS.minisig"
+  if [[ -f "$minisig" ]] && compgen -G "$dir/proxyhub_*.tar.gz" >/dev/null; then
+    if [[ -n "${MINISIGN_PUBKEY_B64:-}" ]]; then
+      verify_minisig "$sums" "$minisig" "$MINISIGN_PUBKEY_B64" || return 1
+    else
+      verify_minisig "$sums" "$minisig" || return 1
+    fi
+    log "OK SHA256SUMS.minisig (minisign signature over SHA256SUMS)"
+    return 0
+  fi
+  if [[ ! -f "$minisig" && -n "${MINISIGN_KEY_FILE:-}" ]]; then
+    log "SHA256SUMS.minisig missing in $dir but MINISIGN_KEY_FILE is set - signing was requested, refusing to pass"
+    return 1
+  fi
+  log "WARN: no SHA256SUMS.minisig in $dir - skipping signature check (unsigned local rehearsal)"
+  return 0
+}
+
 main() {
   (($# >= 1)) || fail "usage: verify.sh <dir-with-SHA256SUMS | tarball.tar.gz [...]>"
 
@@ -59,14 +102,21 @@ main() {
     ((count > 0)) || fail "$sums lists no assets"
     ((failures == 0)) || fail "$failures of $count asset(s) failed verification"
     log "all $count asset(s) verified against $sums"
+    verify_dir_signature "$dir" || fail "signature verification failed in $dir"
     return 0
   fi
 
   local tarball
+  local -A seen_dirs=()
   for tarball in "$@"; do
     sums="$(dirname "$tarball")/SHA256SUMS"
     [[ -f "$sums" ]] || fail "no SHA256SUMS next to $tarball"
     verify_one "$tarball" "$sums" || fail "verification failed for $tarball"
+    dir="$(dirname "$tarball")"
+    if [[ -z "${seen_dirs[$dir]:-}" ]]; then
+      seen_dirs[$dir]=1
+      verify_dir_signature "$dir" || fail "signature verification failed in $dir"
+    fi
   done
   log "all tarball(s) verified"
 }

--- a/scripts/release/verify.sh
+++ b/scripts/release/verify.sh
@@ -74,6 +74,10 @@ verify_dir_signature() {
     log "OK SHA256SUMS.minisig (minisign signature over SHA256SUMS)"
     return 0
   fi
+  if [[ -f "$minisig" ]] && ! compgen -G "$dir/proxyhub_*.tar.gz" >/dev/null; then
+    log "WARN: SHA256SUMS.minisig present in $dir but no proxyhub_*.tar.gz - nothing to verify"
+    return 0
+  fi
   if [[ ! -f "$minisig" && -n "${MINISIGN_KEY_FILE:-}" ]]; then
     log "SHA256SUMS.minisig missing in $dir but MINISIGN_KEY_FILE is set - signing was requested, refusing to pass"
     return 1


### PR DESCRIPTION
## 概述

让国内用户可用一键安装器(ADR 0036):① 信任锚从传输通道挪到密码学签名——release 流水线用 minisign 给 SHA256SUMS 签名,安装器/更新器内嵌公钥 + openssl 验签(零新增依赖),制品从任何通道下载都不影响真实性;② `--download-base` 参数覆盖下载基(默认永远 GitHub 官方,不内置第三方镜像),jsDelivr 作为国内入口文档化。

- Spec: #23(15 条用户故事、10 条实现决策)
- Tickets: #24 #25 #26 #27 #28(全部落地)

## 实现要点

- **签名信任锚**:release.yml 用 MINISIGN_PRIVATE_KEY(GitHub Secrets)签 SHA256SUMS(legacy 格式 `minisign -S -l`),签名后内嵌公钥回验再上传;缺 secret 硬失败。验签端纯 openssl(Ed25519 SPKI 重建 + pkeyutl),目标机零新增依赖
- **--download-base**:覆盖连通性自检(404 容忍)、制品/校验和/签名下载;镜像模式必须显式 `--version`;无静默回退;档案 `DOWNLOAD_BASE=` 记录
- **update 同源**:沿用档案下载基(显式优先、旧档案缺省官方)、镜像无版本拒绝、验签失败不碰在役二进制;status 输出生效下载基
- **jsDelivr 入口**:伴侣库 jsDelivr 优先、raw 后备;override 强制 https;公钥环境变量仅测试模式可覆盖
- **文档**:DEPLOY.md 国内部署大节(入口/镜像配方/auto-update 警示/caddy 加速器/GeoIP/信任锚)、FAQ 三条、ACCEPTANCE 测试 14-15

## 测试

- `make check` 全绿(vet + Go + 8 个 shell 套件 + 前端 lint);新增 ~90 条断言(验签正负例、下载基贯穿、镜像纪律、update 沿用、404 容忍、明文拒绝)
- 打包演练:本地临时密钥签名 + verify.sh 验签(含供应链替换负例)全过;CI 签名 run 块本机逐行模拟过
- pre-push 门禁:gitleaks 全历史零泄漏、Check agent 攻击面评审 SHIP(1 MEDIUM + 4 LOW 已全部修复:明文 override 拒绝、信任锚环境锁、jsDelivr 缓存披露等)

## 已知后续(不阻塞)

- lib.sh 1063 行 / proxyhubctl 1407 行 / cmd_update 253 行——行数治理票
- minisig 测试 helper 三份拷贝(测试间无共享机制)
- release.yml 的签名步骤首次真实执行将在本版发布时(v0.4.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
